### PR TITLE
Fix FQDN length issues for private cluster

### DIFF
--- a/pkg/exporter/azureblob_exporter.go
+++ b/pkg/exporter/azureblob_exporter.go
@@ -14,6 +14,10 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 )
 
+const (
+	maxContainerNameLength = 63
+)
+
 // AzureBlobExporter defines an Azure Blob Exporter
 type AzureBlobExporter struct{}
 
@@ -28,6 +32,9 @@ func (exporter *AzureBlobExporter) Export(files []string) error {
 
 	containerName := strings.Replace(APIServerFQDN, ".", "-", -1)
 	len := strings.Index(containerName, "-hcp-")
+	if len == -1 {
+		len = maxContainerNameLength
+	}
 	containerName = containerName[:len]
 
 	ctx := context.Background()


### PR DESCRIPTION
Private cluster fqdn format is `*.UUID.privatelink.<region-name>.azmk8s.io`, use first 63 char as container name.