### PR TITLE
Storage name starting and ending with "-" is invalid name.

### DIFF
--- a/pkg/exporter/azureblob_exporter.go
+++ b/pkg/exporter/azureblob_exporter.go
@@ -35,7 +35,7 @@ func (exporter *AzureBlobExporter) Export(files []string) error {
 	if len == -1 {
 		len = maxContainerNameLength
 	}
-	containerName = containerName[:len]
+	containerName = strings.TrimRight(containerName[:len], "-")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
This fixes the trailing dash `-` in storage name issue. Associated with https://github.com/Azure/aks-periscope/pull/20 

* Its kind of undocumented, but some pseudo mention here: https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names 

cc: @feiskyer and @JunSun17 