### PR TITLE
Add v0.3 acr image for Private cluster fix.

### DIFF
--- a/deployment/aks-periscope.yaml
+++ b/deployment/aks-periscope.yaml
@@ -69,7 +69,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: aks-periscope
-        image: aksrepos.azurecr.io/staging/aks-periscope:v0.2
+        image: aksrepos.azurecr.io/staging/aks-periscope:v0.3
         securityContext:
           privileged: true
         imagePullPolicy: Always


### PR DESCRIPTION
This is prep for adding `acr image = v03` to yaml for the private cluster fix to encorporate with `latest` tag.

Once merged, we will add `tag 3` for this version and make sit `latest` tag to this commit. Hence `az-cli` will use the latest.

I have test this with the `jumpbox`, looks good.

![image](https://user-images.githubusercontent.com/6233295/82519782-9d8e0d00-9b76-11ea-8c53-7bf306dce1d1.png)
