### PR TITLE
Add local build and test publish mechanism as programming guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ Alternatively, AKS Periscope can be deployed directly with `kubectl`. See instru
 
 # Programming Guide
 
-To locally build from this project from the root of this repository:
+To locally build this project from the root of this repository:
 
 ```
 CGO_ENABLED=0 GOOS=linux go build -mod=vendor github.com/Azure/aks-periscope/cmd/aks-periscope
 ```
 
-**Tip**: In order to test local changes, user can build the local image via `Dockerfile` and then then push it to your local hub. That way user sould be able to reference this test image in the `deployment\aks-periscope.yaml` `containers` property `image` attribute reference to your published test published docker image. 
+**Tip**: In order to test local changes, user can build the local image via `Dockerfile` and then push it to your local hub. This way, user should be able to reference this test image in the `deployment\aks-periscope.yaml` `containers` property `image` attribute reference to your published test docker image. 
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,21 @@ Alternatively, AKS Periscope can be deployed directly with `kubectl`. See instru
 
 
 # Programming Guide
-To Be Updated.
 
+To locally build from this project from the root of this repository:
+
+```
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor github.com/Azure/aks-periscope/cmd/aks-periscope
+```
+
+**Tip**: In order to test local changes, user can build the local image via `Dockerfile` and then then push it to your local hub. That way user sould be able to reference this test image in the `deployment\aks-periscope.yaml` `containers` property `image` attribute reference to your published test published docker image. 
+
+For example:
+
+```
+docker build -f ./builder/Dockerfile -t <some_docker_repo_name>/<aks-periscope-user-selected-test-name> .
+docker push <some_docker_repo_name>/<aks-periscope-user-selected-test-name> 
+```
 
 # Feedback 
 Feel free to contact aksperiscope@microsoft.com or open an issue with any feedback or questions about AKS Periscope. This is currently a work in progress, but look out for more capabilities to come!


### PR DESCRIPTION
Intent of this PR are as follows: 

* To add more direct local repo building information.
* To locally test this with local version of `docker hub` etc.

Please feel free to add more as comments, or ping me directly (whatever suites): 

* I have also refined and removed whole lot information from the [deleted guide here](https://github.com/Azure/aks-periscope/commit/688032aa68f0a93c30f166eceb29a9fb3bf61d58#diff-fa905989049ceb9dc9abe08d545c9857181e8b26295065bdb355be75c928bfea).

