### PR TITLE
Adding missing strings import.

### DIFF
--- a/tests/aksperiscopeintegration_test.go
+++ b/tests/aksperiscopeintegration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Azure/aks-periscope/pkg/utils"


### PR DESCRIPTION
CI test failing, because of missing `strings` import.

So first clear advantage of adding tests. Thanks.

* Successful test run here for CI : https://github.com/Azure/aks-periscope/pull/40/checks?check_run_id=2267294923 

/hallpass so that I can get the build to green.