### PR TITLE
feat: add OSM logs collector

### DIFF
--- a/deployment/aks-periscope.yaml
+++ b/deployment/aks-periscope.yaml
@@ -17,11 +17,17 @@ metadata:
   name: aks-periscope-role
 rules:
 - apiGroups: ["","metrics.k8s.io"]
-  resources: ["pods", "nodes", "secrets"]
-  verbs: ["get", "watch", "list"]
+  resources: ["pods", "pods/portforward", "nodes", "secrets"]
+  verbs: ["get", "watch", "list", "create"]
 - apiGroups: ["aks-periscope.azure.github.com"]
   resources: ["diagnostics"]
   verbs: ["get", "watch", "list", "create", "patch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -83,7 +89,7 @@ spec:
         - configMapRef:
             name: nodelogs-config
         - configMapRef:
-            name: clustertype-config
+            name: collectors-config
         - secretRef:
             name: azureblob-secret
         volumeMounts:
@@ -136,13 +142,13 @@ metadata:
 data:
   DIAGNOSTIC_NODELOGS_LIST: /var/log/azure/cluster-provision.log /var/log/cloud-init.log
 ---
-apiVersion: v1 
-kind: ConfigMap 
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: clustertype-config
+  name: collectors-config
   namespace: aks-periscope
 data:
-  CLUSTER_TYPE: "managedCluster" # <custom flag>
+  COLLECTOR_LIST: managedCluster # <custom flag>
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,6 +1,11 @@
 package collector
 
-import "github.com/Azure/aks-periscope/pkg/interfaces"
+import (
+	"path/filepath"
+
+	"github.com/Azure/aks-periscope/pkg/interfaces"
+	"github.com/Azure/aks-periscope/pkg/utils"
+)
 
 // Type defines Collector Type
 type Type int
@@ -22,6 +27,8 @@ const (
 	NetworkOutbound
 	// NodeLogs defines NodeLogs Collector Type
 	NodeLogs
+	// Osm defines Open Service Mesh Collector Type
+	Osm
 	// SystemLogs defines SystemLogs Collector Type
 	SystemLogs
 	// SystemPerf defines SystemPerf Collector Type
@@ -30,7 +37,7 @@ const (
 
 // Name returns type name
 func (t Type) name() string {
-	return [...]string{"dns", "containerlogs", "helm", "iptables", "kubeletcmd", "kubeobjects", "networkoutbound", "nodelogs", "systemlogs", "systemperf"}[t]
+	return [...]string{"dns", "containerlogs", "helm", "iptables", "kubeletcmd", "kubeobjects", "networkoutbound", "nodelogs", "osm", "systemlogs", "systemperf"}[t]
 }
 
 // BaseCollector defines Base Collector
@@ -66,6 +73,31 @@ func (b *BaseCollector) Export() error {
 	if b.exporter != nil {
 		return b.exporter.Export(b.collectorFiles)
 	}
+
+	return nil
+}
+
+// CollectKubectlOutputToCollectorFiles collects output of a given kubectl command to a file.
+// Returns kubectl's stderr output if stdout output is empty.
+func (b *BaseCollector) CollectKubectlOutputToCollectorFiles(rootPath string, fileName string, kubeCmds []string) error {
+	outputStreams, err := utils.RunCommandOnContainerWithOutputStreams("kubectl", kubeCmds...)
+	if err != nil {
+		return err
+	}
+
+	// If kubectl stdout output is empty, i.e., there is no resource of this type within the cluster
+	// the absence of this resource is logged in the file with the relevant message from stderr (Ex: "No resource found...").
+	output := outputStreams.Stdout
+	if len(output) == 0 {
+		output = outputStreams.Stderr
+	}
+
+	resourceFile := filepath.Join(rootPath, fileName)
+	if err = utils.WriteToFile(resourceFile, output); err != nil {
+		return err
+	}
+
+	b.AddToCollectorFiles(resourceFile)
 
 	return nil
 }

--- a/pkg/collector/osm_collector.go
+++ b/pkg/collector/osm_collector.go
@@ -1,0 +1,189 @@
+package collector
+
+import (
+	"log"
+	"path/filepath"
+	"regexp"
+
+	"github.com/Azure/aks-periscope/pkg/interfaces"
+	"github.com/Azure/aks-periscope/pkg/utils"
+)
+
+// OsmCollector defines an Osm Collector struct
+type OsmCollector struct {
+	BaseCollector
+}
+
+var _ interfaces.Collector = &OsmCollector{}
+
+// NewOsmCollector is a constructor
+func NewOsmCollector(exporter interfaces.Exporter) *OsmCollector {
+	return &OsmCollector{
+		BaseCollector: BaseCollector{
+			collectorType: Osm,
+			exporter:      exporter,
+		},
+	}
+}
+
+// Collect implements the interface method
+func (collector *OsmCollector) Collect() error {
+	// Get all OSM deployments in order to collect information for various resources across all meshes in the cluster
+	meshList, err := utils.GetResourceList([]string{"get", "deployments", "--all-namespaces", "-l", "app=osm-controller", "-o", "jsonpath={..meshName}"}, " ")
+	if err != nil {
+		return err
+	}
+
+	// Directory where OSM logs will be written to
+	rootPath, err := utils.CreateCollectorDir(collector.GetName())
+	if err != nil {
+		return err
+	}
+
+	for _, meshName := range meshList {
+		meshRootPath := filepath.Join(rootPath, "mesh_"+meshName)
+
+		monitoredNamespaces, err := utils.GetResourceList([]string{"get", "namespaces", "--all-namespaces", "-l", "openservicemesh.io/monitored-by=" + meshName, "-o", "jsonpath={..name}"}, " ")
+		if err != nil {
+			log.Printf("Failed to find any namespaces monitored by OSM named '%s': %+v\n", meshName, err)
+		}
+		controllerNamespaces, err := utils.GetResourceList([]string{"get", "deployments", "--all-namespaces", "-l", "app=osm-controller,meshName=" + meshName, "-o", "jsonpath={..metadata.namespace}"}, " ")
+		if err != nil {
+			log.Printf("Failed to find controller namespace(s) for OSM named '%s': %+v\n", meshName, err)
+		}
+		callNamespaceCollectors(collector, monitoredNamespaces, controllerNamespaces, meshRootPath, meshName)
+		collectGroundTruth(collector, meshRootPath, meshName)
+	}
+	return nil
+}
+
+// callNamespaceCollectors calls functions to collect data for osm-controller namespace and namespaces monitored by a given mesh
+func callNamespaceCollectors(collector *OsmCollector, monitoredNamespaces []string, controllerNamespaces []string, rootPath string, meshName string) {
+	for _, namespace := range monitoredNamespaces {
+		namespaceRootPath := filepath.Join(rootPath, "namespace_"+namespace)
+		if err := collectDataFromEnvoys(collector, namespaceRootPath, namespace); err != nil {
+			log.Printf("Failed to collect Envoy configs in OSM monitored namespace %s: %+v", namespace, err)
+		}
+		collectNamespaceResources(collector, namespaceRootPath, namespace)
+	}
+	for _, namespace := range controllerNamespaces {
+		namespaceRootPath := filepath.Join(rootPath, "controller_namespace_"+namespace)
+		if err := collectPodLogs(collector, namespaceRootPath, namespace); err != nil {
+			log.Printf("Failed to collect pod logs for controller namespace %s: %+v", namespace, err)
+		}
+		collectNamespaceResources(collector, namespaceRootPath, namespace)
+	}
+}
+
+// collectNamespaceResources collects information about general resources in a given namespace
+func collectNamespaceResources(collector *OsmCollector, rootPath string, namespace string) {
+	if err := collectPodConfigs(collector, rootPath, namespace); err != nil {
+		log.Printf("Failed to collect pod configs for ns %s: %+v", namespace, err)
+	}
+
+	var namespaceResourcesMap = map[string][]string{
+		"metadata.json":             {"get", "namespaces", namespace, "-o", "jsonpath={..metadata}", "-o", "json"},
+		"services_list.tsv":         {"get", "services", "-n", namespace, "-o", "wide"},
+		"services.json":             {"get", "services", "-n", namespace, "-o", "json"},
+		"endpoints_list.tsv":        {"get", "endpoints", "-n", namespace, "-o", "wide"},
+		"endpoints.json":            {"get", "endpoints", "-n", namespace, "-o", "json"},
+		"configmaps_list.tsv":       {"get", "configmaps", "-n", namespace, "-o", "wide"},
+		"configmaps.json":           {"get", "configmaps", "-n", namespace, "-o", "json"},
+		"ingresses_list.tsv":        {"get", "ingresses", "-n", namespace, "-o", "wide"},
+		"ingresses.json":            {"get", "ingresses", "-n", namespace, "-o", "json"},
+		"service_accounts_list.tsv": {"get", "serviceaccounts", "-n", namespace, "-o", "wide"},
+		"service_accounts.json":     {"get", "serviceaccounts", "-n", namespace, "-o", "json"},
+		"pods_list.tsv":             {"get", "pods", "-n", namespace, "-o", "wide"},
+	}
+	for fileName, kubeCmds := range namespaceResourcesMap {
+		if err := collector.CollectKubectlOutputToCollectorFiles(rootPath, fileName, kubeCmds); err != nil {
+			log.Printf("Failed to collect %s in OSM monitored namespace %s: %+v", fileName, namespace, err)
+		}
+	}
+}
+
+// collectPodConfigs collects configs for pods in given namespace
+func collectPodConfigs(collector *OsmCollector, rootPath string, namespace string) error {
+	rootPath = filepath.Join(rootPath, "pod_configs")
+	pods, err := utils.GetResourceList([]string{"get", "pods", "-n", namespace, "-o", "jsonpath={..metadata.name}"}, " ")
+	if err != nil {
+		return err
+	}
+	for _, podName := range pods {
+		kubeCmds := []string{"get", "pods", "-n", namespace, podName, "-o", "json"}
+		if err := collector.CollectKubectlOutputToCollectorFiles(rootPath, podName+".json", kubeCmds); err != nil {
+			log.Printf("Failed to collect config for pod %s in OSM monitored namespace %s: %+v", podName, namespace, err)
+		}
+	}
+	return nil
+}
+
+// collectDataFromEnvoys collects Envoy proxy config for pods in monitored namespace: port-forward and curl config dump
+func collectDataFromEnvoys(collector *OsmCollector, rootPath string, namespace string) error {
+	pods, err := utils.GetResourceList([]string{"get", "pods", "-n", namespace, "-o", "jsonpath={..metadata.name}"}, " ")
+	if err != nil {
+		return err
+	}
+	for _, podName := range pods {
+		pid, err := utils.RunBackgroundCommand("kubectl", "port-forward", podName, "-n", namespace, "15000:15000")
+		if err != nil {
+			log.Printf("Failed to collect Envoy config for pod %s in OSM monitored namespace %s: %+v", podName, namespace, err)
+			continue
+		}
+
+		envoyQueries := [5]string{"config_dump", "clusters", "listeners", "ready", "stats"}
+		for _, query := range envoyQueries {
+			responseBody, err := utils.GetUrlWithRetries("http://localhost:15000/"+query, 5)
+			if err != nil {
+				log.Printf("Failed to collect Envoy %s for pod %s in OSM monitored namespace %s: %+v", query, podName, namespace, err)
+				continue
+			}
+			// Remove certificate secrets from Envoy config i.e., "inline_bytes" field from response
+			re := regexp.MustCompile("(?m)[\r\n]+^.*inline_bytes.*$")
+			secretRemovedResponse := re.ReplaceAllString(string(responseBody), "---redacted---")
+
+			fileName := query + "_" + podName + ".txt"
+			resourceFile := filepath.Join(rootPath, "envoy_data", fileName)
+			if err = utils.WriteToFile(resourceFile, secretRemovedResponse); err != nil {
+				log.Printf("Failed to write to file: %+v", err)
+				continue
+			}
+			collector.AddToCollectorFiles(resourceFile)
+		}
+		if err = utils.KillProcess(pid); err != nil {
+			log.Printf("Failed to kill process: %+v", err)
+			continue
+		}
+	}
+	return nil
+}
+
+// collectPodLogs collects logs of every pod in a given namespace
+func collectPodLogs(collector *OsmCollector, rootPath string, namespace string) error {
+	rootPath = filepath.Join(rootPath, "pod_logs")
+	pods, err := utils.GetResourceList([]string{"get", "pods", "-n", namespace, "-o", "jsonpath={..metadata.name}"}, " ")
+	if err != nil {
+		return err
+	}
+	for _, podName := range pods {
+		if err := collector.CollectKubectlOutputToCollectorFiles(rootPath, podName+".log", []string{"logs", "-n", namespace, podName}); err != nil {
+			log.Printf("Failed to collect logs for pod %s: %+v", podName, err)
+		}
+	}
+	return nil
+}
+
+// collectGroundTruth collects ground truth on resources in given mesh
+func collectGroundTruth(collector *OsmCollector, rootPath string, meshName string) {
+	var groundTruthMap = map[string][]string{
+		"all_resources_list.tsv":                 {"get", "all", "--all-namespaces", "-l", "app.kubernetes.io/instance=" + meshName, "-o", "wide"},
+		"all_resources_configs.json":             {"get", "all", "--all-namespaces", "-l", "app.kubernetes.io/instance=" + meshName, "-o", "json"},
+		"mutating_webhook_configurations.json":   {"get", "MutatingWebhookConfiguration", "--all-namespaces", "-l", "app.kubernetes.io/instance=" + meshName, "-o", "json"},
+		"validating_webhook_configurations.json": {"get", "ValidatingWebhookConfiguration", "--all-namespaces", "-l", "app.kubernetes.io/instance=" + meshName, "-o", "json"},
+	}
+	for fileName, kubeCmds := range groundTruthMap {
+		if err := collector.CollectKubectlOutputToCollectorFiles(rootPath, fileName, kubeCmds); err != nil {
+			log.Printf("Failed to collect %s for OSM: %+v", fileName, err)
+		}
+	}
+}

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -29,6 +31,11 @@ type Azure struct {
 // AzureStackCloud defines Azure Stack Cloud configuration
 type AzureStackCloud struct {
 	StorageEndpointSuffix string `json:"storageEndpointSuffix"`
+}
+
+type CommandOutputStreams struct {
+	Stdout string
+	Stderr string
 }
 
 // IsAzureStackCloud returns true if the application is running on Azure Stack Cloud
@@ -121,24 +128,80 @@ func RunCommandOnHost(command string, arg ...string) (string, error) {
 	return string(out), nil
 }
 
-// RunCommandOnContainer runs a command on container system
-func RunCommandOnContainer(command string, arg ...string) (string, error) {
+// RunCommandOnContainerWithOutputStreams runs a command on container system and returns both the stdout and stderr output streams
+func RunCommandOnContainerWithOutputStreams(command string, arg ...string) (CommandOutputStreams, error) {
 	cmd := exec.Command(command, arg...)
 
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	outputStreams := CommandOutputStreams{stdout.String(), stderr.String()}
+
+	if err != nil {
+		return outputStreams, fmt.Errorf("Fail to run command in container: %s", fmt.Sprint(err)+": "+stderr.String())
+	}
+
+	return outputStreams, nil
+}
+
+// RunCommandOnContainer  runs a command on container system and returns the stdout output stream
+func RunCommandOnContainer(command string, arg ...string) (string, error) {
+	outputStreams, err := RunCommandOnContainerWithOutputStreams(command, arg...)
+	return outputStreams.Stdout, err
+}
+
+// RunBackgroundCommand starts running a command on a container system in the background and returns its process ID
+func RunBackgroundCommand(command string, arg ...string) (int, error) {
+	cmd := exec.Command(command, arg...)
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
-	err := cmd.Run()
+	err := cmd.Start()
 	if err != nil {
-		return "", fmt.Errorf("Fail to run command in container: %s", fmt.Sprint(err)+": "+stderr.String())
+		return 0, fmt.Errorf("Start background command in container exited with message %s: %w", stderr.String(), err)
 	}
+	return cmd.Process.Pid, nil
+}
 
-	return out.String(), nil
+// Finds and kills a process with a given process ID
+func KillProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("Find process with pid %d to kill: %w", pid, err)
+	}
+	if err := process.Kill(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Tries to issue an HTTP GET request up to maxRetries times
+func GetUrlWithRetries(url string, maxRetries int) ([]byte, error) {
+	retry := 1
+	for {
+		resp, err := http.Get(url)
+		if err != nil {
+			if retry == maxRetries {
+				return nil, fmt.Errorf("Max retries reached for request HTTP Get %s: %w", url, err)
+			}
+			retry++
+			time.Sleep(5 * time.Second)
+		} else {
+			defer resp.Body.Close()
+			return ioutil.ReadAll(resp.Body)
+		}
+	}
 }
 
 // WriteToFile writes data to a file
 func WriteToFile(fileName string, data string) error {
+	if err := os.MkdirAll(filepath.Dir(fileName), os.ModePerm); err != nil {
+		return fmt.Errorf("Fail to create path directories for file %s: %w", fileName, err)
+	}
 	f, err := os.Create(fileName)
 	if err != nil {
 		return fmt.Errorf("Fail to create file %s: %+v", fileName, err)
@@ -278,6 +341,23 @@ func CreateCRD() error {
 	}
 
 	return nil
+}
+
+// GetResourceList gets a list of all resources of given type in a specified namespace
+func GetResourceList(kubeCmds []string, separator string) ([]string, error) {
+	outputStreams, err := RunCommandOnContainerWithOutputStreams("kubectl", kubeCmds...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	resourceList := outputStreams.Stdout
+	// If the resource is not found within the cluster, then log a message and do not return any resources.
+	if len(resourceList) == 0 {
+		return nil, fmt.Errorf("No '%s' resource found in the cluster for given kubectl command", kubeCmds[1])
+	}
+
+	return strings.Split(strings.Trim(resourceList, "\""), separator), nil
 }
 
 func writeDiagnosticCRD(crdName string) error {


### PR DESCRIPTION
This PR adds collectors for [OSM](https://github.com/openservicemesh/osm) and [SMI](https://smi-spec.io/). SMI collector can be broken out into a separate PR as well.

* Flags: in `aks-periscope.yaml`, setting flags to `OSM` turns on both osm and smi collectors. `SMI` flag turns on just smi collector
* `osm_collector` collects the following for each Open Service Mesh present on the cluster:
  * ground truth - list/configs of all resources and mutating and validating webhook configurations
  * for each osm control plan namespace - pod configs and logs of OSM controller and OSM injector pods
  * for each namespace monitored by osm: metadata, services, endpoints, service accounts, configmaps, etc.
* [moving this into a separate PR] `smi_collector` collects the traffic targets, traffic splits, httproutegroups, tcproutes and udproutes for smi policies being applied.
  * this collector can be used by any service mesh, not just osm