### PR TITLE
Fix for vscode consuming old image with new yaml changes.

### DIFF
--- a/deployment/aks-periscope.yaml
+++ b/deployment/aks-periscope.yaml
@@ -92,6 +92,9 @@ spec:
             name: collectors-config
         - secretRef:
             name: azureblob-secret
+        volumeMounts:
+         - mountPath: /aks-periscope
+           name: aks-periscope-storage
         resources:
           requests:
             memory: "500Mi"
@@ -99,6 +102,11 @@ spec:
           limits:
             memory: "2000Mi"
             cpu: "1000m"
+      volumes:
+       - name: aks-periscope-storage
+         hostPath:
+           path: /var/log/aks-periscope
+           type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
We need to fix the current `master` yaml which is consumed in vscode directly.

* https://github.com/Azure/aks-periscope/pull/65/files#diff-cabcaac1a231e2d530ba374ca786e837a4c7f802f98c86299b93874aaf2e78eaL95 

This opens up and I think we can now start thinking after next release to have cleaner release for customise transition. 

cc: @arnaud-tincelin , thanks 