### PR TITLE
fix for CRD. Only read hostname once and pass it around instead

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -100,8 +100,8 @@ func main() {
 	collectorGrp.Wait()
 
 	diagnosers := []interfaces.Diagnoser{
-		diagnoser.NewNetworkConfigDiagnoser(dnsCollector, kubeletCmdCollector),
-		diagnoser.NewNetworkOutboundDiagnoser(networkOutboundCollector),
+		diagnoser.NewNetworkConfigDiagnoser(hostname, dnsCollector, kubeletCmdCollector),
+		diagnoser.NewNetworkOutboundDiagnoser(hostname, networkOutboundCollector),
 	}
 
 	diagnoserGrp := new(sync.WaitGroup)

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -251,22 +251,13 @@ func GetCreationTimeStamp() (string, error) {
 }
 
 // WriteToCRD writes diagnostic data to CRD
-func WriteToCRD(fileName string, key string) error {
-	hostName, err := GetHostName()
-	if err != nil {
-		return err
-	}
+func WriteToCRD(jsonBytes []byte, key string, hostName string) error {
 
 	crdName := "aks-periscope-diagnostic" + "-" + hostName
 
-	jsonBytes, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		return err
-	}
-
 	patchContent := fmt.Sprintf("{\"spec\":{%q:%q}}", key, string(jsonBytes))
 
-	_, err = RunCommandOnContainer("kubectl", "-n", "aks-periscope", "patch", "apd", crdName, "-p", patchContent, "--type=merge")
+	_, err := RunCommandOnContainer("kubectl", "-n", "aks-periscope", "patch", "apd", crdName, "-p", patchContent, "--type=merge")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
this fixes the bug introduced here: https://github.com/Azure/aks-periscope/commit/cce800065d8835cb1588a48a0176967e45d54cb2

and the issue reported here:
https://github.com/Azure/aks-periscope/issues/81

Bug was introduced during the move to not use files, but the WriteToCRD function still attempted to read from the diagnoser output file