### PR TITLE
Singleton implementation for GetHostName.

### DIFF
--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -24,6 +24,8 @@ const (
 	AzureStackCloudName = "AzureStackCloud"
 )
 
+var GetHostNameFunc = GetHostNameSingleton()
+
 // Azure defines Azure configuration
 type Azure struct {
 	Cloud string `json:"cloud"`
@@ -95,8 +97,8 @@ func GetStorageEndpointSuffix() string {
 }
 
 type HostName struct {
-	hostName string
-	err      error
+	HostName string
+	Err      error
 }
 
 var singletonHostName *HostName
@@ -112,8 +114,8 @@ func GetHostNameSingleton() *HostName {
 		}
 
 		singletonHostName = &HostName{
-			hostName: hostname,
-			err:      err,
+			HostName: hostname,
+			Err:      err,
 		}
 	})
 
@@ -122,12 +124,12 @@ func GetHostNameSingleton() *HostName {
 
 // GetHostName get host name
 func GetHostName() (string, error) {
-	hostName := GetHostNameSingleton()
-	if hostName.err != nil {
-		return "", fmt.Errorf("Fail to get host name: %+v", hostName.err)
+	hostName := GetHostNameFunc
+	if hostName.Err != nil {
+		return "", fmt.Errorf("Fail to get host name: %+v", hostName.Err)
 	}
 
-	return hostName.hostName, nil
+	return hostName.HostName, nil
 }
 
 // GetAPIServerFQDN gets the API Server FQDN from the kubeconfig file

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/Azure/aks-periscope/pkg/utils"
+	. "github.com/onsi/gomega"
+)
+
+func TestGetHostNameSuccessCase(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Save current function and restore at the end:
+	old := utils.GetHostNameFunc
+	defer func() { utils.GetHostNameFunc = old }()
+
+	utils.GetHostNameFunc = &utils.HostName{
+		HostName: "aks-agentpool-20752274-vmss000000",
+		Err:      nil,
+	}
+
+	// setup expectations
+	// call the code we are testing
+	hostname, _ := utils.GetHostName()
+
+	// assert that the expectations were met
+	g.Expect(hostname).To(BeElementOf("aks-agentpool-20752274-vmss000000"))
+}
+
+func TestGetHostNameFailureCase(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Save current function and restore at the end:
+	old := utils.GetHostNameFunc
+	defer func() { utils.GetHostNameFunc = old }()
+
+	utils.GetHostNameFunc = &utils.HostName{
+		HostName: "",
+		Err:      errors.New("an error"),
+	}
+
+	// setup expectations
+	// call the code we are testing
+	_, err := utils.GetHostName()
+	log.Printf("Error is %s", err)
+	// assert that the expectations were met
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err).To(BeElementOf(errors.New("Fail to get host name: an error")))
+
+}


### PR DESCRIPTION
This PR intends to Fix the multiple `GetHostName` calls to Singleton call using `Sync.Once.Do`

This PR also try to attempt and simplify the deep parameter passing mechanism. Why using `Sync.Once` because its a thread safe go existing pkg funct which we can use.  https://pkg.go.dev/sync#Once .

Please note: feel free to add your variable naming preferences but this way will ensure that the call for the actual `run command` only happens once. **Advantage** of this approach is that all changes reside under `utils` umbrella, no extra func parameter will be required, and it will guarantee the actual code is ran only once. 

Another, pro is that the call to the method stays same, under the hood it only gets called once. For future any new diagnostics or anything which needs to call the `utils.GetHostName` don't need to worry about running many times, and no more parameter passing as well.

* **Tested with Image local**: docker.io/tatsat/singleton-call-changes 

This pR also simplifies this PR: https://github.com/Azure/aks-periscope/pull/82 

Thanks guys. 🙏


<img width="1306" alt="Screen Shot 2021-07-20 at 9 11 12 PM" src="https://user-images.githubusercontent.com/6233295/126294902-b8cc33be-3db6-4900-99b2-e57d27f85c7a.png">


**Unit test result**

<img width="1709" alt="Screen Shot 2021-07-21 at 2 06 46 AM" src="https://user-images.githubusercontent.com/6233295/126338466-57f5c7b4-6ebf-4cc1-965e-b11a465a47bc.png">
