### PR TITLE
Feature/kubectl to client go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/Azure/aks-periscope/actions/workflows/ci-pipeline.yml/badge.svg?branch=master)](https://github.com/Azure/aks-periscope/actions/workflows/ci-pipeline.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/Azure/aks-periscope)](https://goreportcard.com/report/github.com/Azure/aks-periscope)
+[![CI](https://github.com/Azure/aks-periscope/actions/workflows/ci-pipeline.yaml/badge.svg?branch=master)](https://github.com/Azure/aks-periscope/actions/workflows/ci-pipeline.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/Azure/aks-periscope)](https://goreportcard.com/report/github.com/Azure/aks-periscope)
 
 # AKS Periscope
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/Azure/aks-periscope/actions/workflows/ci-pipeline.yaml/badge.svg?branch=master)](https://github.com/Azure/aks-periscope/actions/workflows/ci-pipeline.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/Azure/aks-periscope)](https://goreportcard.com/report/github.com/Azure/aks-periscope)
+[![CI](https://github.com/Azure/aks-periscope/actions/workflows/ci-pipeline.yml/badge.svg?branch=master)](https://github.com/Azure/aks-periscope/actions/workflows/ci-pipeline.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/Azure/aks-periscope)](https://goreportcard.com/report/github.com/Azure/aks-periscope)
 
 # AKS Periscope
 

--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -56,7 +56,7 @@ func main() {
 	ipTablesCollector := collector.NewIPTablesCollector()
 	nodeLogsCollector := collector.NewNodeLogsCollector()
 	kubeletCmdCollector := collector.NewKubeletCmdCollector()
-	systemPerfCollector := collector.NewSystemPerfCollector()
+	systemPerfCollector := collector.NewSystemPerfCollector(config)
 	helmCollector := collector.NewHelmCollector(config)
 	osmCollector := collector.NewOsmCollector()
 	smiCollector := collector.NewSmiCollector()

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/onsi/gomega v1.13.0
 	helm.sh/helm/v3 v3.6.3
+	k8s.io/apimachinery v0.21.3
 	k8s.io/cli-runtime v0.21.3
 	k8s.io/client-go v0.21.3
+	k8s.io/metrics v0.21.0
 	rsc.io/letsencrypt v0.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1170,6 +1170,7 @@ k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7Br
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kubectl v0.21.0 h1:WZXlnG/yjcE4LWO2g6ULjFxtzK6H1TKzsfaBFuVIhNg=
 k8s.io/kubectl v0.21.0/go.mod h1:EU37NukZRXn1TpAkMUoy8Z/B2u6wjHDS4aInsDzVvks=
+k8s.io/metrics v0.21.0 h1:uwS3CgheLKaw3PTpwhjMswnm/PMqeLbdLH88VI7FMQQ=
 k8s.io/metrics v0.21.0/go.mod h1:L3Ji9EGPP1YBbfm9sPfEXSpnj8i24bfQbAFAsW0NueQ=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/pkg/collector/systemperf_collector.go
+++ b/pkg/collector/systemperf_collector.go
@@ -18,14 +18,14 @@ type SystemPerfCollector struct {
 
 type NodeMetrics struct {
 	NodeName    string `json:"name"`
-	CPUUsage    int64  `json:"cpuusage"`
-	MemoryUsage int64  `json:"memoryusage"`
+	CPUUsage    int64  `json:"cpuUsage"`
+	MemoryUsage int64  `json:"memoryUsage"`
 }
 
 type PodMetrics struct {
 	ContainerName string `json:"name"`
-	CPUUsage      int64  `json:"cpuusage"`
-	MemoryUsage   int64  `json:"memoryusage"`
+	CPUUsage      int64  `json:"cpuUsage"`
+	MemoryUsage   int64  `json:"memoryUsage"`
 }
 
 // NewSystemPerfCollector is a constructor
@@ -47,7 +47,6 @@ func (collector *SystemPerfCollector) Collect() error {
 		return fmt.Errorf("metrics for config error: %w", err)
 	}
 
-	// Node Metrics collector
 	nodeMetrics, err := metric.MetricsV1beta1().NodeMetricses().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("node metrics error: %w", err)
@@ -77,7 +76,6 @@ func (collector *SystemPerfCollector) Collect() error {
 
 	collector.data["nodes"] = string(jsonNodeResult)
 
-	// Pod Metrics collector
 	podMetrics, err := metric.MetricsV1beta1().PodMetricses(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("pod metrics failure: %w", err)

--- a/pkg/collector/systemperf_collector.go
+++ b/pkg/collector/systemperf_collector.go
@@ -1,18 +1,38 @@
 package collector
 
 import (
-	"github.com/Azure/aks-periscope/pkg/utils"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	restclient "k8s.io/client-go/rest"
+	metrics "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
 // SystemPerfCollector defines a SystemPerf Collector struct
 type SystemPerfCollector struct {
-	data map[string]string
+	kubeconfig *restclient.Config
+	data       map[string]string
+}
+
+type NodeMetrics struct {
+	NodeName    string `json:"name"`
+	CPUUsage    int64  `json:"cpuusage"`
+	MemoryUsage int64  `json:"memoryusage"`
+}
+
+type PodMetrics struct {
+	ContainerName string `json:"name"`
+	CPUUsage      int64  `json:"cpuusage"`
+	MemoryUsage   int64  `json:"memoryusage"`
 }
 
 // NewSystemPerfCollector is a constructor
-func NewSystemPerfCollector() *SystemPerfCollector {
+func NewSystemPerfCollector(config *restclient.Config) *SystemPerfCollector {
 	return &SystemPerfCollector{
-		data: make(map[string]string),
+		data:       make(map[string]string),
+		kubeconfig: config,
 	}
 }
 
@@ -22,23 +42,73 @@ func (collector *SystemPerfCollector) GetName() string {
 
 // Collect implements the interface method
 func (collector *SystemPerfCollector) Collect() error {
-	if err := utils.CreateKubeConfigFromServiceAccount(); err != nil {
-		return err
-	}
-
-	output, err := utils.RunCommandOnContainer("kubectl", "top", "nodes")
+	metric, err := metrics.NewForConfig(collector.kubeconfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("metrics for config error: %w", err)
 	}
 
-	collector.data["nodes"] = output
-
-	output, err = utils.RunCommandOnContainer("kubectl", "top", "pods", "--all-namespaces")
+	// Node Metrics collector
+	nodeMetrics, err := metric.MetricsV1beta1().NodeMetricses().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("node metrics error: %w", err)
 	}
 
-	collector.data["pods"] = output
+	noderesult := make([]NodeMetrics, 0)
+
+	for _, nodeMetric := range nodeMetrics.Items {
+		cpuQuantity := nodeMetric.Usage.Cpu().MilliValue()
+		memQuantity, ok := nodeMetric.Usage.Memory().AsInt64()
+		if !ok {
+			return err
+		}
+
+		nm := NodeMetrics{
+			NodeName:    nodeMetric.Name,
+			CPUUsage:    cpuQuantity,
+			MemoryUsage: memQuantity,
+		}
+
+		noderesult = append(noderesult, nm)
+	}
+	jsonNodeResult, err := json.Marshal(noderesult)
+	if err != nil {
+		return fmt.Errorf("marshall node metrics to json: %w", err)
+	}
+
+	collector.data["nodes"] = string(jsonNodeResult)
+
+	// Pod Metrics collector
+	podMetrics, err := metric.MetricsV1beta1().PodMetricses(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("pod metrics failure: %w", err)
+	}
+
+	podresult := make([]PodMetrics, 0)
+
+	for _, podMetric := range podMetrics.Items {
+		podContainers := podMetric.Containers
+		for _, container := range podContainers {
+			cpuQuantity := container.Usage.Cpu().MilliValue()
+			memQuantity, ok := container.Usage.Memory().AsInt64()
+			if !ok {
+				return fmt.Errorf("usage memory failure: %w", err)
+			}
+
+			pm := PodMetrics{
+				ContainerName: container.Name,
+				CPUUsage:      cpuQuantity,
+				MemoryUsage:   memQuantity,
+			}
+
+			podresult = append(podresult, pm)
+		}
+	}
+	jsonPodResult, err := json.Marshal(podresult)
+	if err != nil {
+		return fmt.Errorf("marshall pod metrics to json: %w", err)
+	}
+
+	collector.data["pods"] = string(jsonPodResult)
 
 	return nil
 }

--- a/pkg/collector/systemperf_collector_test.go
+++ b/pkg/collector/systemperf_collector_test.go
@@ -1,0 +1,58 @@
+package collector
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestSystemperfCollector(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "get node logs",
+			want:    1,
+			wantErr: false,
+		},
+	}
+
+	dirname, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("Cannot get user home dir: %v", err)
+	}
+
+	master := ""
+	kubeconfig := path.Join(dirname, ".kube/config")
+	config, err := clientcmd.BuildConfigFromFlags(master, kubeconfig)
+	if err != nil {
+		t.Fatalf("Cannot load kube config: %v", err)
+	}
+
+	c := NewSystemPerfCollector(config)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.Collect()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Collect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			raw := c.GetData()["nodes"]
+			var nodeMetrices []NodeMetrics
+
+			if err := json.Unmarshal([]byte(raw), &nodeMetrices); err != nil {
+				t.Errorf("unmarshal GetData(): %v", err)
+			}
+
+			if len(nodeMetrices) < tt.want {
+				t.Errorf("len(GetData()) = %v, want %v", len(nodeMetrices), tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -239,36 +239,6 @@ func GetUrlWithRetries(url string, maxRetries int) ([]byte, error) {
 	}
 }
 
-// CreateKubeConfigFromServiceAccount creates kubeconfig based on creds in service account
-func CreateKubeConfigFromServiceAccount() error {
-	token, err := RunCommandOnContainer("cat", "/var/run/secrets/kubernetes.io/serviceaccount/token")
-	if err != nil {
-		return err
-	}
-
-	_, err = RunCommandOnContainer("kubectl", "config", "set-credentials", "aks-periscope-service-account", "--token="+token)
-	if err != nil {
-		return err
-	}
-
-	_, err = RunCommandOnContainer("kubectl", "config", "set-cluster", "aks-periscope-cluster", "--server=https://kubernetes.default.svc.cluster.local:443", "--certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
-	if err != nil {
-		return err
-	}
-
-	_, err = RunCommandOnContainer("kubectl", "config", "set-context", "aks-periscope-context", "--user=aks-periscope-service-account", "--cluster=aks-periscope-cluster")
-	if err != nil {
-		return err
-	}
-
-	_, err = RunCommandOnContainer("kubectl", "config", "use-context", "aks-periscope-context")
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // GetCreationTimeStamp returns a create timestamp
 func GetCreationTimeStamp() (string, error) {
 	creationTimeStamp, err := RunCommandOnContainer("kubectl", "get", "pods", "--all-namespaces", "-l", "app=aks-periscope", "-o", "jsonpath=\"{.items[0].metadata.creationTimestamp}\"")


### PR DESCRIPTION
This PR is the `client-go` implementation and move away from `os.exec` - `kubectl` execution. That way we will be able to remove the `os.exec` dependency and `kubectl binary` in docker image.

please note: due to the way client-go objects work in order to form the CPU% I need to identify total cores etc, which is not part of this PR, will be awesomee to get some thoughts on that as well please. thanks guys.

* To start with this initial work takes a dig at the existing `system-err_collector` and tends to move it away from direct `kubectl` implementation to `client-go` implementation.
* https://github.com/kubernetes/client-go - is a Kubernetes `client-go` source code.

Thanks, 🙏 ^Tats

Opening this for wider opinion and suggestions.

cc: @arnaud-tincelin , @davidkydd, @JunSun17 and anyone interested, Thanks

Any new collectors should spend time doing this way.