### PR TITLE
Use os.open function for reading files.

### DIFF
--- a/pkg/collector/dns_collector.go
+++ b/pkg/collector/dns_collector.go
@@ -24,7 +24,7 @@ func (collector *DNSCollector) GetName() string {
 func (collector *DNSCollector) Collect() error {
 	result := make(map[string]string)
 
-	output, err := utils.RunCommandOnHost("cat", "/etc/resolv.conf")
+	output, err := utils.ReadFileContent("/etc/resolv.conf")
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/nodelogs_collector.go
+++ b/pkg/collector/nodelogs_collector.go
@@ -1,9 +1,10 @@
 package collector
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/Azure/aks-periscope/pkg/utils"
 )
 
 // NodeLogsCollector defines a NodeLogs Collector struct
@@ -28,19 +29,12 @@ func (collector *NodeLogsCollector) Collect() error {
 
 	for _, nodeLog := range nodeLogs {
 
-		output, err := os.Open(nodeLog)
+		output, err := utils.ReadFileContent(nodeLog)
 		if err != nil {
 			return err
 		}
 
-		defer output.Close()
-
-		b, err := ioutil.ReadAll(output)
-		if err != nil {
-			return err
-		}
-
-		collector.data["nodeLog"] = string(b)
+		collector.data["nodeLog"] = output
 	}
 
 	return nil

--- a/pkg/collector/nodelogs_collector.go
+++ b/pkg/collector/nodelogs_collector.go
@@ -1,10 +1,9 @@
 package collector
 
 import (
+	"io/ioutil"
 	"os"
 	"strings"
-
-	"github.com/Azure/aks-periscope/pkg/utils"
 )
 
 // NodeLogsCollector defines a NodeLogs Collector struct
@@ -29,13 +28,19 @@ func (collector *NodeLogsCollector) Collect() error {
 
 	for _, nodeLog := range nodeLogs {
 
-		output, err := utils.RunCommandOnHost("cat", nodeLog)
+		output, err := os.Open(nodeLog)
 		if err != nil {
 			return err
 		}
 
-		collector.data["nodeLog"] = output
+		defer output.Close()
 
+		b, err := ioutil.ReadAll(output)
+		if err != nil {
+			return err
+		}
+
+		collector.data["nodeLog"] = string(b)
 	}
 
 	return nil

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -41,6 +41,22 @@ type CommandOutputStreams struct {
 	Stderr string
 }
 
+func ReadFileContent(filename string) (string, error) {
+	output, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+
+	defer output.Close()
+
+	b, err := ioutil.ReadAll(output)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
 // IsAzureStackCloud returns true if the application is running on Azure Stack Cloud
 func IsAzureStackCloud() bool {
 	azureFile, err := RunCommandOnHost("cat", "/etc/kubernetes/azure.json")


### PR DESCRIPTION
This PR kind of closes all the discussion where it was recommended not to use `RunCommandOnHost` for things like `cat` for file because that can be easily done at via `os.Open` which open files. Much better and reduces over-use of `RunCommandonHost`.

* Test with this image: `docker.io/tatsat/redundant-runcommand-use` 

Thanks.