### PR TITLE
Add v0.4 image to new release.

### DIFF
--- a/deployment/aks-periscope.yaml
+++ b/deployment/aks-periscope.yaml
@@ -77,7 +77,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: aks-periscope
-        image: aksrepos.azurecr.io/staging/aks-periscope:v0.3
+        image: aksrepos.azurecr.io/staging/aks-periscope:v0.4
         securityContext:
           privileged: true
         imagePullPolicy: Always
@@ -93,7 +93,7 @@ spec:
         - secretRef:
             name: azureblob-secret
         volumeMounts:
-         - mountPath: /aks-periscope
+         - mountPath: /var/log/
            name: aks-periscope-storage
         resources:
           requests:
@@ -105,7 +105,7 @@ spec:
       volumes:
        - name: aks-periscope-storage
          hostPath:
-           path: /var/log/aks-periscope
+           path: /var/log/
            type: DirectoryOrCreate
 ---
 apiVersion: v1


### PR DESCRIPTION
This is prep for adding acr image = v0.4 to yaml for list of fixes for 34 small to medium size workitems [release here](https://github.com/Azure/aks-periscope/releases/tag/untagged-c60b581a606b7a6453f4).

Once merged, we will add tag v0.4 for this version and make sit latest tag to this commit. Hence az-cli will use the latest as well and with master change vscode will use latest as well.

Thanks heaps,

@JunSun17 , @arnaud-tincelin , @qpetraroia , and @rzhang628 Thanks heaps 🙏