### PR TITLE
Add consuming tool yaml

### DIFF
--- a/deployment/consuming-tools/aks-periscope.yaml
+++ b/deployment/consuming-tools/aks-periscope.yaml
@@ -1,0 +1,179 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aks-periscope
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aks-periscope-service-account
+  namespace: aks-periscope
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aks-periscope-role
+rules:
+- apiGroups: ["","metrics.k8s.io"]
+  resources: ["pods", "pods/portforward", "nodes", "secrets"]
+  verbs: ["get", "watch", "list", "create"]
+- apiGroups: ["aks-periscope.azure.github.com"]
+  resources: ["diagnostics"]
+  verbs: ["get", "watch", "list", "create", "patch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aks-periscope-role-binding
+subjects:
+- kind: ServiceAccount
+  name: aks-periscope-service-account
+  namespace: aks-periscope
+roleRef:
+  kind: ClusterRole
+  name: aks-periscope-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aks-periscope-role-binding-view
+subjects:
+- kind: ServiceAccount
+  name: aks-periscope-service-account
+  namespace: aks-periscope
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aks-periscope
+  namespace: aks-periscope
+  labels:
+    app: aks-periscope
+spec:
+  selector:
+    matchLabels:
+      app: aks-periscope
+  template:
+    metadata:
+      labels:
+        app: aks-periscope
+    spec:
+      serviceAccountName: aks-periscope-service-account
+      hostPID: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - name: aks-periscope
+        image: aksrepos.azurecr.io/staging/aks-periscope:0.5
+        securityContext:
+          privileged: true
+        imagePullPolicy: Always
+        envFrom:
+        - configMapRef:
+            name: containerlogs-config
+        - configMapRef:
+            name: kubeobjects-config
+        - configMapRef:
+            name: nodelogs-config
+        - configMapRef:
+            name: collectors-config
+        - secretRef:
+            name: azureblob-secret
+        volumeMounts:
+         - mountPath: /var/log/
+           name: aks-periscope-storage
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "250m"
+          limits:
+            memory: "2000Mi"
+            cpu: "1000m"
+      volumes:
+       - name: aks-periscope-storage
+         hostPath:
+           path: /var/log/
+           type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azureblob-secret
+  namespace: aks-periscope
+type: Opaque
+data:
+  AZURE_BLOB_SAS_KEY: # <saskey, base64 encoded>
+  AZURE_BLOB_ACCOUNT_NAME: # <accountName, base64 encoded>
+  AZURE_BLOB_CONTAINER_NAME: # <containerName, base64 encoded>
+---
+apiVersion: v1 
+kind: ConfigMap 
+metadata:
+  name: containerlogs-config
+  namespace: aks-periscope
+data:
+  DIAGNOSTIC_CONTAINERLOGS_LIST: kube-system
+---
+apiVersion: v1 
+kind: ConfigMap 
+metadata:
+  name: kubeobjects-config
+  namespace: aks-periscope
+data:
+  DIAGNOSTIC_KUBEOBJECTS_LIST: kube-system/pod kube-system/service kube-system/deployment
+---
+apiVersion: v1 
+kind: ConfigMap 
+metadata:
+  name: nodelogs-config
+  namespace: aks-periscope
+data:
+  DIAGNOSTIC_NODELOGS_LIST: /var/log/azure/cluster-provision.log /var/log/cloud-init.log
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collectors-config
+  namespace: aks-periscope
+data:
+  COLLECTOR_LIST: managedCluster # <custom flag>
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: diagnostics.aks-periscope.azure.github.com
+spec:
+  group: aks-periscope.azure.github.com
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            dns:
+              type: string
+            networkoutbound:
+              type: string
+  scope: Namespaced
+  names:
+    plural: diagnostics
+    singular: diagnostic
+    kind: Diagnostic
+    shortNames:
+    - apd


### PR DESCRIPTION
This is PR is to create one place for the consuming tool yaml consumption for periscope deployment. Currently, from `az-cli`, `vs-code` and now `arc` consuming same mechanism just to deploy `kubectl apply -f <deployment file>` and trying to use the `kustomize` built up is added noise at the system level at individual tool level which is unwanted noise.

With container name decoupled - and now even validation for 3-63 character limit is responsibility of the tool, we will need to a non-repetitive logic and hence here is what happens if I try to form it via `kustomize` build:

**Important** All these steps will be repetitive in every tool and easiest way we can resolve this is to hold the fix - deployment file at this repo level.

For example: Before even we start we get Containername in Vscode from Cluster-info

* we first create a `deployment file` then
* we `read and replace` the string to `storageName, key, containerName`, then
* we actually kubectl Kustomize the file to get real `deployment`. then
* we run the deployment file.

There are 2 more intermediate in-memory steps, but seems like the `kustomize` file build is not correctly formed so I have update Arnaud about it.

Feel free to add your discussion point or add it in internal chat. Thanks heaps guys. 🙏☕️

Some part of it is discussed here : https://github.com/Azure/aks-periscope/issues/79

cc: @rzhang628 and @qpetraroia + @arnaud-tincelin 


