### PR TITLE
Arc pod-container logs client-go implementations with unit-tests.

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -59,7 +59,7 @@ func main() {
 	helmCollector := collector.NewHelmCollector(config)
 	osmCollector := collector.NewOsmCollector()
 	smiCollector := collector.NewSmiCollector()
-	podsCollector := collector.NewPODSContainerLogs(config)
+	podsCollector := collector.NewPodsContainerLogs(config)
 
 	collectors := []interfaces.Collector{
 		dnsCollector,

--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -59,6 +59,7 @@ func main() {
 	helmCollector := collector.NewHelmCollector(config)
 	osmCollector := collector.NewOsmCollector()
 	smiCollector := collector.NewSmiCollector()
+	podsCollector := collector.NewPODSContainerLogs(config)
 
 	collectors := []interfaces.Collector{
 		dnsCollector,
@@ -68,6 +69,7 @@ func main() {
 
 	if contains(collectorList, "connectedCluster") {
 		collectors = append(collectors, helmCollector)
+		collectors = append(collectors, podsCollector)
 	} else {
 		collectors = append(collectors, systemLogsCollector)
 		collectors = append(collectors, ipTablesCollector)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/onsi/gomega v1.13.0
 	helm.sh/helm/v3 v3.6.3
+	k8s.io/api v0.21.3 // indirect
 	k8s.io/apimachinery v0.21.3
 	k8s.io/cli-runtime v0.21.3
 	k8s.io/client-go v0.21.3

--- a/pkg/collector/pods_containerlogs_collector.go
+++ b/pkg/collector/pods_containerlogs_collector.go
@@ -1,0 +1,170 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+)
+
+// PODSContainerLogsCollector defines a Pods Container Logs Collector struct
+type PODSContainerLogsCollector struct {
+	kubeconfig *restclient.Config
+	data       map[string]string
+}
+
+type PODSContainerStruct struct {
+	Name          string
+	Ready         string
+	Status        string
+	Restart       int32
+	Age           time.Duration
+	ContainerName string
+	ContainerLog  string
+}
+
+// NewPODSContainerLogs is a constructor
+func NewPODSContainerLogs(config *restclient.Config) *PODSContainerLogsCollector {
+	return &PODSContainerLogsCollector{
+		data:       make(map[string]string),
+		kubeconfig: config,
+	}
+}
+
+func (collector *PODSContainerLogsCollector) GetName() string {
+	return "podscontainerlogs"
+}
+
+// Collect implements the interface method
+func (collector *PODSContainerLogsCollector) Collect() error {
+	containerNamespaces := strings.Fields(os.Getenv("DIAGNOSTIC_CONTAINERLOGS_LIST"))
+
+	// Creates the clientset
+	clientset, err := kubernetes.NewForConfig(collector.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("error in getting access to K8S: %v", err)
+	}
+
+	for _, namespace := range containerNamespaces {
+		// List the pods in the given namespace
+		podList, err := getPods(clientset, namespace)
+
+		if err != nil {
+			return fmt.Errorf("error while getting pods: %v", err)
+		}
+
+		// List all the pods similar to kubectl get pods -n <my namespace>
+		for _, pod := range podList.Items {
+			// Calculate the age of the pod
+			podCreationTime := pod.GetCreationTimestamp()
+			age := time.Since(podCreationTime.Time).Round(time.Second)
+
+			// Get the status of each of the pods
+			podStatus := pod.Status
+
+			var containerRestarts int32
+			var containerReady int
+
+			// If a pod has multiple containers, get the status from all
+			for container := range pod.Spec.Containers {
+				containerRestarts += podStatus.ContainerStatuses[container].RestartCount
+
+				if podStatus.ContainerStatuses[container].Ready {
+					containerReady++
+				}
+			}
+			containerName := pod.Spec.Containers[0].Name
+			// Get pods container logs
+			containerLogs, err := getPodContainerLogs(namespace, pod.Name, containerName, clientset)
+
+			if err != nil {
+				return fmt.Errorf("error while getting container logs: %v", err)
+			}
+
+			podsContainerData := &PODSContainerStruct{
+				Name:          pod.Name,
+				Ready:         fmt.Sprintf("%v/%v", containerReady, len(pod.Spec.Containers)),
+				Status:        string(podStatus.Phase),
+				Restart:       containerRestarts,
+				Age:           age,
+				ContainerName: containerName,
+				ContainerLog:  containerLogs,
+			}
+
+			data, err := json.Marshal(podsContainerData)
+			if err != nil {
+				return fmt.Errorf("error in marshalling podsContainerData: %v", err)
+			}
+
+			// Append this to data to be printed in a table
+			collector.data[pod.Name] = string(data)
+		}
+	}
+
+	return nil
+}
+
+func (collector *PODSContainerLogsCollector) GetData() map[string]string {
+	return collector.data
+}
+
+func getPods(clientset *kubernetes.Clientset, namespace string) (*v1.PodList, error) {
+	// Create a pod interface for the given namespace
+	podInterface := clientset.CoreV1().Pods(namespace)
+
+	// List the pods in the given namespace
+	podList, err := podInterface.List(context.TODO(), metav1.ListOptions{})
+
+	if err != nil {
+		return nil, fmt.Errorf("error in getting pods: %v", err)
+	}
+
+	return podList, nil
+}
+
+func getPodContainerLogs(
+	namespace string,
+	podName string,
+	containerName string,
+	clientset *kubernetes.Clientset) (string, error) {
+
+	count := int64(100)
+	podLogOptions := v1.PodLogOptions{
+		Container: containerName,
+		TailLines: &count,
+	}
+
+	podLogRequest := clientset.CoreV1().
+		Pods(namespace).
+		GetLogs(podName, &podLogOptions)
+	stream, err := podLogRequest.Stream(context.Background())
+
+	if err != nil {
+		return "", fmt.Errorf("error in getting pod logs request: %v", err)
+	}
+	defer stream.Close()
+	returnData := ""
+	for {
+		buf := make([]byte, 2000)
+		numBytes, err := stream.Read(buf)
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return "", fmt.Errorf("error in pod logs stream read: %v", err)
+		}
+		returnData = string(buf[:numBytes])
+	}
+
+	return returnData, err
+}

--- a/pkg/collector/pods_containerlogs_collector_test.go
+++ b/pkg/collector/pods_containerlogs_collector_test.go
@@ -1,0 +1,56 @@
+package collector
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestPODSContainerLogsCollector(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "get pods container logs",
+			want:    1,
+			wantErr: false,
+		},
+	}
+
+	dirname, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("Cannot get user home dir: %v", err)
+	}
+
+	master := ""
+	kubeconfig := path.Join(dirname, ".kube/config")
+	config, err := clientcmd.BuildConfigFromFlags(master, kubeconfig)
+	if err != nil {
+		t.Fatalf("Cannot load kube config: %v", err)
+	}
+
+	c := NewPODSContainerLogs(config)
+
+	if err := os.Setenv("DIAGNOSTIC_CONTAINERLOGS_LIST", "kube-system"); err != nil {
+		t.Fatalf("Setenv: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.Collect()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Collect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			raw := c.GetData()
+
+			if len(raw) < tt.want {
+				t.Errorf("len(GetData()) = %v, want %v", len(raw), tt.want)
+			}
+		})
+	}
+}

--- a/pkg/collector/pods_containerlogs_collector_test.go
+++ b/pkg/collector/pods_containerlogs_collector_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func TestPODSContainerLogsCollector(t *testing.T) {
+func TestPodsContainerLogsCollector(t *testing.T) {
 	tests := []struct {
 		name    string
 		want    int
@@ -33,7 +33,7 @@ func TestPODSContainerLogsCollector(t *testing.T) {
 		t.Fatalf("Cannot load kube config: %v", err)
 	}
 
-	c := NewPODSContainerLogs(config)
+	c := NewPodsContainerLogs(config)
 
 	if err := os.Setenv("DIAGNOSTIC_CONTAINERLOGS_LIST", "kube-system"); err != nil {
 		t.Fatalf("Setenv: %v", err)


### PR DESCRIPTION
This PR achieves following: 

* This work is to enable/help-out arc for their scenario of collecting the `azure-arc` namespace with container `manager` for their use case purposes. Further detail on this work item reside here: https://github.com/Azure/aks-periscope/issues/105 

* This implementation as commit include : `client-go` implementation along with `Test Coverage` and @sophsoph321 will have an initial playground regarding the nitty-gritty of client-go implementation, ~and she can kindly make this fit the need of scenario for arc.~ (I have now incorporated all the changes you will need to fetch the `pod-container-logs`).

* `Unit test addition`: I have added unit-test and ~some `fmt & log.printf` at places for you to see outputs locally as well, this will also help in code coverage of this work as well.~

* Test Image: `docker.io/tatsat/pods-container-logs` 

Thanks Heaps,
^Tats

cc: @arnaud-tincelin , @sophsoph321 , @rzhang628 , @safeermohammed , @qpetraroia Thanks guys!


**Just for sample:** I altered the logger for non-arc cluster to show the logs.

Here is where container logs will reside and a sample from a kube-system run from vanilla AKS:

<img width="462" alt="Screen Shot 2021-08-31 at 8 14 41 PM" src="https://user-images.githubusercontent.com/6233295/131467950-1cbce6f2-b1e4-41e4-9a2b-a3b099b735aa.png">


<img width="1032" alt="Screen Shot 2021-08-31 at 8 15 28 PM" src="https://user-images.githubusercontent.com/6233295/131467688-275fb6bf-6a09-454c-9e16-0712e6631091.png">
