### PR TITLE
Unit-test for network-bound collectors.

### DIFF
--- a/pkg/collector/networkoutbound_collector_test.go
+++ b/pkg/collector/networkoutbound_collector_test.go
@@ -1,0 +1,36 @@
+package collector
+
+import (
+	"testing"
+)
+
+func TestNewNetworkOutboundCollector(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "get networkbound logs",
+			want:    1,
+			wantErr: false,
+		},
+	}
+
+	c := NewNetworkOutboundCollector()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.Collect()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Collect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			raw := c.GetData()
+
+			if len(raw) < tt.want {
+				t.Errorf("len(GetData()) = %v, want %v", len(raw), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds `unit-test` for the `network bound-collector`, key motivation is to improve code base quality along with code-cov. 

Thanks.

cc: @arnaud-tincelin 🙏☕️  & fyi: @rzhang628 and @qpetraroia 
