### PR TITLE
dns logs will contain error rather than actual pod error visibility.

### DIFF
--- a/pkg/collector/dns_collector.go
+++ b/pkg/collector/dns_collector.go
@@ -24,14 +24,14 @@ func (collector *DNSCollector) GetName() string {
 func (collector *DNSCollector) Collect() error {
 	output, err := utils.ReadFileContent("/etchostlogs/resolv.conf")
 	if err != nil {
-		return err
+		output = err.Error()
 	}
 
 	collector.data["virtualmachine"] = output
 
 	output, err = utils.ReadFileContent("/etc/resolv.conf")
 	if err != nil {
-		return err
+		output = err.Error()
 	}
 
 	collector.data["kubernetes"] = output

--- a/pkg/collector/dns_collector_test.go
+++ b/pkg/collector/dns_collector_test.go
@@ -1,0 +1,34 @@
+package collector
+
+import (
+	"testing"
+)
+
+func TestNewDNSCollector(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "get dns logs",
+			want:    1,
+			wantErr: false,
+		},
+	}
+
+	c := NewDNSCollector()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.Collect()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Collect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			raw := c.GetData()
+			if len(raw) < tt.want {
+				t.Errorf("len(GetData()) = %v, want %v", len(raw), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is the work for ARC for log level error visibility in case od DNS logs than pods level error visibility.

Thanks,


* Test image : `docker.io/tatsat/dns-logs-visibility` 

Thank you guys ☕️  : @arnaud-tincelin , @sophsoph321 and @safeermohammed 