### PR TITLE
osm/smi: update dir structure and add test

### DIFF
--- a/deployment/cluster-role.yaml
+++ b/deployment/cluster-role.yaml
@@ -12,6 +12,3 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list", "watch"]
-- apiGroups: ["access.smi-spec.io", "specs.smi-spec.io", "split.smi-spec.io"]
-  resources: ["*"]
-  verbs: ["get", "list", "watch"]

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.7.0
 	github.com/Azure/go-autorest/autorest/adal v0.9.14 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
-	github.com/onsi/gomega v1.13.0
+	github.com/onsi/gomega v1.13.0 // indirect
 	helm.sh/helm/v3 v3.6.3
-	k8s.io/api v0.21.3 // indirect
+	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3
 	k8s.io/cli-runtime v0.21.3
 	k8s.io/client-go v0.21.3

--- a/pkg/collector/osm_collector_test.go
+++ b/pkg/collector/osm_collector_test.go
@@ -1,0 +1,56 @@
+package collector
+
+import (
+	"os"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestOsmCollector(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    int
+		wantErr bool
+		deployments []*appsv1.Deployment
+		collectorName string
+	}{
+		{
+			name:    "no deployments found",
+			want:    0,
+			wantErr: true,
+			deployments: []*appsv1.Deployment{},
+			collectorName: "osm",
+		},
+	}
+
+	c := NewOsmCollector()
+
+	if err := os.Setenv("COLLECTOR_LIST", "OSM"); err != nil {
+		t.Fatalf("Setenv: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]runtime.Object, len(tt.deployments))
+			for i := range tt.deployments {
+				objs[i] = tt.deployments[i]
+			}
+			err := c.Collect()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Collect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			raw := c.GetData()
+
+			if len(raw) < tt.want {
+				t.Errorf("len(GetData()) = %v, want %v", len(raw), tt.want)
+			}
+			name := c.GetName()
+			if name != tt.collectorName {
+				t.Errorf("GetName()) = %v, want %v", name, tt.collectorName)
+			}
+		})
+	}
+}

--- a/pkg/collector/smi_collector.go
+++ b/pkg/collector/smi_collector.go
@@ -58,7 +58,7 @@ func collectSmiCrds(collector *SmiCollector, smiCrdsList []string) {
 		if err != nil {
 			log.Printf("Skipping: unable to collect yaml definition of %s: %+v", smiCrd, err)
 		}
-		collector.data["smi_crd_definition_"+smiCrd] = yamlDefinition
+		collector.data["smi/crd_"+strings.TrimSuffix(smiCrd, ".io")] = yamlDefinition
 	}
 }
 
@@ -90,7 +90,7 @@ func collectSmiCustomResourcesFromNamespace(collector *SmiCollector, smiCrdsList
 			if err != nil {
 				log.Printf("Skipping: unable to collect yaml definition of %s (custom resource type: %s): %+v", customResourceName, smiCrdType, err)
 			}
-			collector.data["namespace_"+namespace+"_"+smiCrdType+"_custom_resource_"+customResourceName] = yamlDefinition
+			collector.data["smi/namespace_"+namespace+"/"+smiCrdType+"_"+customResourceName+"_custom_resource"] = yamlDefinition
 		}
 	}
 }


### PR DESCRIPTION
- Updates to collect osm custom resource meshconfig per latest osm release
- Fixes collection of smi crds (rbac in cluster-role)
- Adds naming structure to filename: `meshName/resourceName_resourceType` and `smi/resourceName_resourceType>`
- Tested with kustomize `kubectl apply -k deployment` 

