### PR TITLE
Use client-go and remove unecessary kubectl.

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -16,7 +16,12 @@ import (
 )
 
 func main() {
-	creationTimeStamp, err := utils.GetCreationTimeStamp()
+	config, err := restclient.InClusterConfig()
+	if err != nil {
+		log.Fatalf("Cannot load kubeconfig: %v", err)
+	}
+
+	creationTimeStamp, err := utils.GetCreationTimeStamp(config)
 	if err != nil {
 		log.Fatalf("Failed to get creation timestamp: %v", err)
 	}
@@ -24,10 +29,6 @@ func main() {
 	hostname, err := utils.GetHostName()
 	if err != nil {
 		log.Fatalf("Failed to get the hostname on which AKS Periscope is running: %v", err)
-	}
-
-	if err := utils.CreateCRD(); err != nil {
-		log.Fatalf("Failed to create CRD: %v", err)
 	}
 
 	collectorList := strings.Fields(os.Getenv("COLLECTOR_LIST"))
@@ -39,11 +40,6 @@ func main() {
 		if err := utils.CopyFileFromHost("/etc/ssl/certs/azsCertificate.pem", "/etc/ssl/certs/azsCertificate.pem"); err != nil {
 			log.Fatalf("Cannot copy cert for Azure Stack Cloud environment: %v", err)
 		}
-	}
-
-	config, err := restclient.InClusterConfig()
-	if err != nil {
-		log.Fatalf("Cannot load kubeconfig: %v", err)
 	}
 
 	dataProducers := []interfaces.DataProducer{}

--- a/pkg/diagnoser/networkconfig_diagnoser.go
+++ b/pkg/diagnoser/networkconfig_diagnoser.go
@@ -91,10 +91,6 @@ func (diagnoser *NetworkConfigDiagnoser) Diagnose() error {
 
 	diagnoser.data["networkconfig"] = string(dataBytes)
 
-	if err = utils.WriteToCRD(string(dataBytes), diagnoser.GetName()); err != nil {
-		return fmt.Errorf("write data from NetworkConfig Diagnoser to CRD: %w", err)
-	}
-
 	return nil
 }
 

--- a/pkg/diagnoser/networkoutbound_diagnoser.go
+++ b/pkg/diagnoser/networkoutbound_diagnoser.go
@@ -86,11 +86,6 @@ func (diagnoser *NetworkOutboundDiagnoser) Diagnose() error {
 
 	diagnoser.data["networkoutbound"] = string(dataBytes)
 
-	err = utils.WriteToCRD(string(dataBytes), diagnoser.GetName())
-	if err != nil {
-		return fmt.Errorf("write data from NetworkOutbound Diagnoser to CRD: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This PR is important for 2 reasons:

* This pull request removes leftover kubectl dependencies and the only leftovers are the `OSM` and `SMI` collectors only.
* This pull request moves the repo more closer to a goal of stop using the `kubectl` command and use `client-go` module instead.

The work also redo the `creationTime` fetch and removes bunch of stuff which seems like unnecessary and not in need, I will ping JunSUn to take a look but I have tested this agains the vanilla `AKS Cluster` and seems to be behaving fine.

* Test image: `docker.io/tatsat/misc-move-to-client-go` 

Thanks,

cc: @rzhang628 , @arnaud-tincelin, @JunSun17 , @sophsoph321 , plus @bcho ❤️🙏☕️