### PR TITLE
Wait for all operations to finish.

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -60,7 +60,6 @@ func main() {
 	osmCollector := collector.NewOsmCollector()
 	smiCollector := collector.NewSmiCollector()
 	podsCollector := collector.NewPodsContainerLogs(config)
-	pdbCollector := collector.NewPDBCollector(config)
 
 	collectors := []interfaces.Collector{
 		dnsCollector,
@@ -77,7 +76,6 @@ func main() {
 		collectors = append(collectors, nodeLogsCollector)
 		collectors = append(collectors, kubeletCmdCollector)
 		collectors = append(collectors, systemPerfCollector)
-		collectors = append(collectors, pdbCollector)
 	}
 
 	// OSM and SMI flags are mutually exclusive
@@ -161,6 +159,7 @@ func main() {
 
 	// TODO: remove this //nolint comment once the select{} has been removed
 	//nolint:govet}
+}
 
 func contains(flagsList []string, flag string) bool {
 	for _, f := range flagsList {

--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -153,9 +152,13 @@ func main() {
 		}
 	}
 	exporterGrp.Wait()
-	log.Printf("Main: Completed")
-	fmt.Println("Main: Completed")
-}
+
+	// TODO: Hack: for now AKS-Periscope is running as a deamonset so it shall not stop (or the pod will be restarted)
+	// Revert from https://github.com/Azure/aks-periscope/blob/b98d66a238e942158ef2628a9315b58937ff9c8f/cmd/aks-periscope/aks-periscope.go#L70
+	select {}
+
+	// TODO: remove this //nolint comment once the select{} has been removed
+	//nolint:govet}
 
 func contains(flagsList []string, flag string) bool {
 	for _, f := range flagsList {

--- a/pkg/exporter/azureblob_exporter.go
+++ b/pkg/exporter/azureblob_exporter.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/Azure/aks-periscope/pkg/interfaces"
 	"github.com/Azure/aks-periscope/pkg/utils"
@@ -121,7 +122,8 @@ func (exporter *AzureBlobExporter) Export(producer interfaces.DataProducer) erro
 	return nil
 }
 
-func (exporter *AzureBlobExporter) ExportReader(name string, reader io.ReadSeeker) error {
+func (exporter *AzureBlobExporter) ExportReader(wg *sync.WaitGroup, name string, reader io.ReadSeeker) error {
+	defer wg.Done()
 	containerURL, err := createContainerURL()
 	if err != nil {
 		return err

--- a/pkg/exporter/zip.go
+++ b/pkg/exporter/zip.go
@@ -3,11 +3,13 @@ package exporter
 import (
 	"archive/zip"
 	"bytes"
+	"sync"
 
 	"github.com/Azure/aks-periscope/pkg/interfaces"
 )
 
-func Zip(data []interfaces.DataProducer) (*bytes.Buffer, error) {
+func Zip(wg *sync.WaitGroup, data []interfaces.DataProducer) (*bytes.Buffer, error) {
+	defer wg.Done()
 	buffer := new(bytes.Buffer)
 	z := zip.NewWriter(buffer)
 	defer z.Close()


### PR DESCRIPTION
This pull request caters #30 and indirectly caters a issue which very rarely seen in some consuming tools like https://github.com/Azure/vscode-aks-tools/issues/44 

Just like collectors we have now added `wait` logic for the `zip` and `export to storage` functionality.

Happy to detail more if anyone keen, but I think the linked issues will help in understanding the idea behind this fix. Gist is that the operation of upload still happening at the background and by adding `wait` we are guaranteeing that this tool will return 100% success upload before it finishes, earlier the tool runs at the background due to `select {}` which leads to this kind of behaviour, as detailed: https://github.com/Azure/vscode-aks-tools/issues/44  its similar behaviour in az-cli as well.

* test image: `docker.io/tatsat/wait-for-all-operations`  

Thanks heaps,

cc: @rzhang628 , @arnaud-tincelin , @peterbom , @sophsoph321 , @bcho 🙏☕️❤️
