### PR TITLE
update v1beta1 apiextension to v1.

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  GO_VERSION: '1.15'
+  GO_VERSION: '1.16.1'
   KIND_VERSION: v0.11.1
   HELM_VERSION: v3.4.0
 
@@ -110,7 +110,7 @@ jobs:
           (cd ./deployment && kustomize edit set image aksrepos.azurecr.io/staging/aks-periscope=localhost:5000/periscope:foo)
           kubectl apply -f <(kustomize build ./deployment)
           kubectl -n aks-periscope describe ds aks-periscope
-          kubectl -n aks-periscope wait po --all --for condition=ready --timeout=60s
+          kubectl -n aks-periscope wait po --all --for condition=ready --timeout=240s
       - name: Go tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
       - name: Upload coverage to Codecov

--- a/deployment/crd.yaml
+++ b/deployment/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: diagnostics.aks-periscope.azure.github.com
@@ -8,17 +8,17 @@ spec:
   - name: v1
     served: true
     storage: true
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          properties:
-            dns:
-              type: string
-            networkoutbound:
-              type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              dns:
+                type: string
+              networkoutbound:
+                type: string
   scope: Namespaced
   names:
     plural: diagnostics

--- a/deployment/crd.yaml
+++ b/deployment/crd.yaml
@@ -19,6 +19,8 @@ spec:
                 type: string
               networkoutbound:
                 type: string
+              networkconfig:
+                type: string
   scope: Namespaced
   names:
     plural: diagnostics


### PR DESCRIPTION
This PR fixes the deprecation of `apiextensions.k8s.io/v1beta1` now moved to `v1`

* More details here: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122

This will avoid warnings like: `Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+;` 

Please note: ~this needs to be tested~. 

* Tested with: `docker.io/tatsat/deprecated-extension-crd-api`

Thanks. ☕️🙏

