### PR TITLE
Enable mechanism for container sas key to be passed.

### DIFF
--- a/deployment/daemon-set.yaml
+++ b/deployment/daemon-set.yaml
@@ -19,7 +19,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: aks-periscope
-        image: aksrepos.azurecr.io/staging/aks-periscope
+        image: mcr.microsoft.com/aks/periscope
         securityContext:
           privileged: true
         imagePullPolicy: Always

--- a/deployment/kustomization.yaml
+++ b/deployment/kustomization.yaml
@@ -13,5 +13,5 @@ resources:
 - service-account.yaml
 
 images:
-  - name: aksrepos.azurecr.io/staging/aks-periscope
-    newTag: v0.3
+  - name: mcr.microsoft.com/aks/periscope
+    newTag: v0.6

--- a/pkg/exporter/azureblob_exporter.go
+++ b/pkg/exporter/azureblob_exporter.go
@@ -20,6 +20,16 @@ type AzureBlobExporter struct {
 	creationTime string
 }
 
+type StorageKeyType string
+
+const (
+	Container StorageKeyType = "Container"
+)
+
+var storageKeyTypes = map[string]StorageKeyType{
+	"Container": Container,
+}
+
 func NewAzureBlobExporter(creationTime, hostname string) *AzureBlobExporter {
 	return &AzureBlobExporter{
 		hostname:     hostname,
@@ -31,6 +41,7 @@ func createContainerURL() (azblob.ContainerURL, error) {
 	accountName := os.Getenv("AZURE_BLOB_ACCOUNT_NAME")
 	sasKey := os.Getenv("AZURE_BLOB_SAS_KEY")
 	containerName := os.Getenv("AZURE_BLOB_CONTAINER_NAME")
+	keyType := os.Getenv("AZURE_STORAGE_SAS_KEY_TYPE")
 
 	if accountName == "" || sasKey == "" || containerName == "" {
 		log.Print("Storage Account information were not provided. Export to Azure Storage Account will be skiped.")
@@ -48,6 +59,10 @@ func createContainerURL() (azblob.ContainerURL, error) {
 	}
 
 	containerURL := azblob.NewContainerURL(*url, pipeline)
+
+	if _, ok := storageKeyTypes[keyType]; ok {
+		return containerURL, nil
+	}
 
 	_, err = containerURL.Create(ctx, azblob.Metadata{}, azblob.PublicAccessNone)
 	if err != nil {


### PR DESCRIPTION
This PR enables container sas key to be supplied as `...SAS_KEY` env var.

Day 1 behaviour of this tool is to accept the storage account level sas key which helps in enabling the `create` behaviour for the tools where container gets created if it doesn't exist, but now since we support passing the `Container_Name` as one of the feature it is natural trajectory to enable the flag which depicts its container sas.

Following change will enable will enable the container level sas to be consumed form the deployment file. All user need to do is to add this in their deployment file in case they are passing the container sas key under the `AZURE_STORAGE_SAS_KEY_TYPE `.

``` 
spec:
    :::::::
    :::::::
    - name: AZURE_STORAGE_SAS_KEY_TYPE
       value: "Container"
    :::::::
```

### Why its done this way?

This approach is the simplest, will not effect existing behaviour and least convoluted. Currently the `azure storage golang sdk` doesnot support `exist` without forming a client which needs `Account_key` also `create will fail` https://github.com/Azure/azure-storage-blob-go/blob/master/azblob/url_container.go#L84 

### Advantage:

Even though this tool is run client side, this will enable the feature for anyone really keen to user container sas and since we allow account level sas this makes sense as to enable for anyone who just want to pass the container level sas for existing container.

### Image to test:

* `docker.io/tatsat/container-sas-upload` If anyone wants to test.

Thanks,

cc: @rzhang628, @SanyaKochhar, @sophsoph321, @arnaud-tincelin , @bcho or @peterbom if anyone of you guys please take a look. 🙏☕️❤️


