### PR TITLE
Temporary disabling non-compliant collectors from test cov.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "pkg/collector/osm_collector.go"
+  - "pkg/collector/smi_collector.go"


### PR DESCRIPTION
This PR is to make sure that `SMI and OSM` collector move to `client-go` before the test for these collector should be enabled, the discussion is in progress and I think Sanya and Johnson will work to get this almost done, there is a `SMI` PR already open and need `OSM and SMI` to make changes according to their need.

The key aspect to this it to get rid of `kubectl` binary.

in the mean time this PR will remove the code coverage of these 2 collectors, and all needs to be done is to remove these collector from this file when they are converted.

Thanks heaps, ❤️🙏☕️