### PR TITLE
Feature/enable build publish workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -34,21 +34,15 @@ jobs:
         run: go mod download
       - name: Build project
         run: go build ./cmd/aks-periscope
-      - name: Run the changelog reader
+      - name: Get Changelog Entry
         id: changelog_reader
-        uses: ./
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          validation_depth: 10
+          path: ./CHANGELOG.md
       - name: Display output
         run: |
           echo "Version: ${{ steps.changelog_reader.outputs.version }}"
-      - name: Create a Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-        with:
-          tag_name : ${{ steps.changelog_reader.outputs.current-version}}
-          release_name: ${{ steps.changelog_reader.outputs.current-version}}
-          body: Publish ${{ steps.changelog_reader.outputs.current-version}}
       # Lowercase my github ownername.
       - name: Set Environment Variables
         run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -36,7 +36,12 @@ jobs:
         run: go mod download
       - name: Build project
         run: go build ./cmd/aks-periscope
-
+      - name: Run the changelog reader
+        id: changelog_reader
+        uses: ./
+      - name: Display output
+        run: |
+          echo "Version: ${{ steps.changelog_reader.outputs.version }}"
       # Lowercase my github ownername.
       - name: Set Environment Variables
         run: |
@@ -56,5 +61,5 @@ jobs:
           docker build -f ./builder/Dockerfile -t aks/periscope .
           echo "start docker build done"
           echo "start docker tag"
-          docker tag aks/periscope ghcr.io/${{ env.REPO-OWNER }}/aks/periscope:test-image-tag-live-demo
-          docker push $(registryLoginServerName)/public/aks/periscope:test-image-tag-live-demo
+          docker tag aks/periscope ghcr.io/${{ env.REPO-OWNER }}/aks/periscope:${{ steps.changelog_reader.outputs.version }}
+          docker push $(registryLoginServerName)/public/aks/periscope:${{ steps.changelog_reader.outputs.version }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,60 @@
+# This is a basic workflow to help you get started with Actions
+name: Bundle building and pushing
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on: [workflow_dispatch]
+
+env:
+  GO_VERSION: '1.16.1'
+  KIND_VERSION: v0.11.1
+  HELM_VERSION: v3.4.0
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Linter
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Download modules
+        run: go mod download
+      - name: Build project
+        run: go build ./cmd/aks-periscope
+
+      # Lowercase my github ownername.
+      - name: Set Environment Variables
+        run: |
+          OWNER="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          echo "REPO-OWNER=${OWNER}" >> $GITHUB_ENV
+
+      - name: Login to GitHub Packages OCI Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PASSWORD }} # requires you to have a GH token and place it in a secret "GHCR_PASSWORD"
+      - name: Porter publish to ghcr.io 
+      # Note the below automatically sets the registry to the local GH registry of the org name. 
+      # Currently, for pure gitops reconstructing this runtime setting will require looking at the repository owner of the commit
+        run: |
+          docker build -f ./builder/Dockerfile -t aks/periscope .
+          echo "start docker build done"
+          echo "start docker tag"
+          docker tag aks/periscope ghcr.io/${{ env.REPO-OWNER }}/aks/periscope:test-image-tag-live-demo
+          docker push $(registryLoginServerName)/public/aks/periscope:test-image-tag-live-demo

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -7,8 +7,6 @@ on: [workflow_dispatch]
 
 env:
   GO_VERSION: '1.16.1'
-  KIND_VERSION: v0.11.1
-  HELM_VERSION: v3.4.0
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -42,6 +40,15 @@ jobs:
       - name: Display output
         run: |
           echo "Version: ${{ steps.changelog_reader.outputs.version }}"
+      - name: Create a Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        with:
+          tag_name : ${{ steps.changelog_reader.outputs.current-version}}
+          release_name: ${{ steps.changelog_reader.outputs.current-version}}
+          body: Publish ${{ steps.changelog_reader.outputs.current-version}}
       # Lowercase my github ownername.
       - name: Set Environment Variables
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+## [0.0.8]
+
+* A few minor edits to README.md by @davefellows in #147
+* Add pod disrupution budget information collector. by @Tatsinnit in #135
+* Behaviour fix, Upload API fix. by @Tatsinnit in #138
+* Use client-go and remove unnecessary kubectl. by @Tatsinnit in #136
+* update v1beta1 apiextension to v1. by @Tatsinnit in #139
+* Improve CI and add iptables and kubeletcmd test structure. by @Tatsinnit in #140
+* Enable mechanism for container sas key to be passed. by @Tatsinnit in #143
+* add systemlogs test. by @Tatsinnit in #149
+* Temporary disabling non-compliant collectors from test cov. by @Tatsinnit in #144
+
+
+Thanks to @sophsoph321, @peterbom, @davefellows, @rzhang628, @bcho, @SanyaKochhar, @johnsonshi for interactions, reviews and various enagements.


### PR DESCRIPTION
Opening this for wider eyes and as PR for enabling `GHCR publishing` for the repo, please note this can also be a blue print PR for other repos Matt Stam + other projects et. al. are working for the publishing of the `ACR` Images, only thing which will change is the registry and mechanism of publishing.

Here is a quick detail of actions:

* Workflow is on `trigger` only, (So admin for the repo can do that)
* Then, workflow checkout repo, then it used `ChangeLog` action for checking out the version. https://github.com/mindsers/changelog-reader-action
* After that, the workflow triggers the `GHCR` publishing mechanism.

Thanks heaps, 