### PR TITLE
Return error from createContainerURL if storage settings are not configured

### DIFF
--- a/pkg/exporter/azureblob_exporter.go
+++ b/pkg/exporter/azureblob_exporter.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -44,8 +45,8 @@ func createContainerURL() (azblob.ContainerURL, error) {
 	keyType := os.Getenv("AZURE_STORAGE_SAS_KEY_TYPE")
 
 	if accountName == "" || sasKey == "" || containerName == "" {
-		log.Print("Storage Account information were not provided. Export to Azure Storage Account will be skiped.")
-		return azblob.ContainerURL{}, nil
+		log.Print("Storage Account information were not provided. Export to Azure Storage Account will be skipped.")
+		return azblob.ContainerURL{}, errors.New("Storage not configured.")
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
This fixes a CI built timeout caused by the `aks-periscope` pods crash-looping.

The crashing behaviour was introduced by #96 but only occurs intermittently because the the pods are briefly in `Ready` state, so the `kubectl -n aks-periscope wait po --all --for condition=ready --timeout=240s` command sometimes completes successfully.

Previously to the above change, the `createContainerURL` function used to fail with an error due to no `kubeconfig` file existing, meaning that the process would complete (and sleep) without attempting to write anything to blob storage. Following that change, the absence of storage configuration would fail _without_ returning an error, and the process would attempt to write to an empty blob URL, resulting in a panic and crash.

This fixes that function so it explicitly returns an error if storage settings are not configured, which seems like it should be the desired behaviour anyway.