### PR TITLE
Fix Node Logs Collector to use separate keys for each log file

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -39,42 +39,24 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - name: REMOVE ME 1
-        run: |
-          ls -al /var/log/
       - uses: actions/checkout@v2
         with:
             fetch-depth: 2
-      - name: REMOVE ME 2
-        run: |
-          ls -al /var/log/
       - uses: azure/setup-kubectl@v1
-      - name: REMOVE ME 3
-        run: |
-          ls -al /var/log/
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: REMOVE ME 4
-        run: |
-          ls -al /var/log/
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
           version: ${{ env.HELM_VERSION }}
-      - name: REMOVE ME 5
-        run: |
-          ls -al /var/log/
       - name: Install Packages
         run: |
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64
           chmod +x ./kind
 
           curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-      - name: REMOVE ME 6
-        run: |
-          ls -al /var/log/
       - name: Start kind
         run: |
           docker run -d --restart=always -p "127.0.0.1:5000:5000" --name "registry" registry:2
@@ -107,16 +89,10 @@ jobs:
               help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
           EOF
         continue-on-error: false
-      - name: REMOVE ME 7
-        run: |
-          ls -al /var/log/
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
           driver-opts: network=host
-      - name: REMOVE ME 8
-        run: |
-          ls -al /var/log/
       - name: Build and push to local registry
         uses: docker/build-push-action@v2
         with:
@@ -124,31 +100,19 @@ jobs:
           push: true
           tags: localhost:5000/periscope:${{ github.run_id }}
           file: ./builder/Dockerfile
-      - name: REMOVE ME 9
-        run: |
-          ls -al /var/log/
       - name: Deploy dummy helm chart for tests
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update
           helm install happy-panda bitnami/wordpress --namespace default
-      - name: REMOVE ME 10
-        run: |
-          ls -al /var/log/
       - name: Deploy AKS Periscope
         run: |
           (cd ./deployment && kustomize edit set image mcr.microsoft.com/aks/periscope=localhost:5000/periscope:${{ github.run_id }})
           kubectl apply -f <(kustomize build ./deployment)
           kubectl -n aks-periscope describe ds aks-periscope
           kubectl -n aks-periscope wait po --all --for condition=ready --timeout=240s
-      - name: REMOVE ME 11
-        run: |
-          ls -al /var/log/
       - name: Go tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
-      - name: REMOVE ME 12
-        run: |
-          ls -al /var/log/
       - name: Upload coverage to Codecov
         run: bash <(curl -s https://codecov.io/bash) -C $(Build.SourceVersion)
       - name: Stop kind

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -39,24 +39,42 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
+      - name: REMOVE ME 1
+        run: |
+          ls -al /var/log/
       - uses: actions/checkout@v2
         with:
             fetch-depth: 2
+      - name: REMOVE ME 2
+        run: |
+          ls -al /var/log/
       - uses: azure/setup-kubectl@v1
+      - name: REMOVE ME 3
+        run: |
+          ls -al /var/log/
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+      - name: REMOVE ME 4
+        run: |
+          ls -al /var/log/
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
           version: ${{ env.HELM_VERSION }}
+      - name: REMOVE ME 5
+        run: |
+          ls -al /var/log/
       - name: Install Packages
         run: |
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64
           chmod +x ./kind
 
           curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+      - name: REMOVE ME 6
+        run: |
+          ls -al /var/log/
       - name: Start kind
         run: |
           docker run -d --restart=always -p "127.0.0.1:5000:5000" --name "registry" registry:2
@@ -89,10 +107,16 @@ jobs:
               help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
           EOF
         continue-on-error: false
+      - name: REMOVE ME 7
+        run: |
+          ls -al /var/log/
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
           driver-opts: network=host
+      - name: REMOVE ME 8
+        run: |
+          ls -al /var/log/
       - name: Build and push to local registry
         uses: docker/build-push-action@v2
         with:
@@ -100,19 +124,31 @@ jobs:
           push: true
           tags: localhost:5000/periscope:${{ github.run_id }}
           file: ./builder/Dockerfile
+      - name: REMOVE ME 9
+        run: |
+          ls -al /var/log/
       - name: Deploy dummy helm chart for tests
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update
           helm install happy-panda bitnami/wordpress --namespace default
+      - name: REMOVE ME 10
+        run: |
+          ls -al /var/log/
       - name: Deploy AKS Periscope
         run: |
           (cd ./deployment && kustomize edit set image mcr.microsoft.com/aks/periscope=localhost:5000/periscope:${{ github.run_id }})
           kubectl apply -f <(kustomize build ./deployment)
           kubectl -n aks-periscope describe ds aks-periscope
           kubectl -n aks-periscope wait po --all --for condition=ready --timeout=240s
+      - name: REMOVE ME 11
+        run: |
+          ls -al /var/log/
       - name: Go tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+      - name: REMOVE ME 12
+        run: |
+          ls -al /var/log/
       - name: Upload coverage to Codecov
         run: bash <(curl -s https://codecov.io/bash) -C $(Build.SourceVersion)
       - name: Stop kind

--- a/pkg/collector/nodelogs_collector.go
+++ b/pkg/collector/nodelogs_collector.go
@@ -28,14 +28,17 @@ func (collector *NodeLogsCollector) Collect() error {
 	nodeLogs := strings.Fields(os.Getenv("DIAGNOSTIC_NODELOGS_LIST"))
 
 	for _, nodeLog := range nodeLogs {
+		normalizedNodeLog := strings.Replace(nodeLog, "/", "_", -1)
+		if normalizedNodeLog[0] == '_' {
+			normalizedNodeLog = normalizedNodeLog[1:]
+		}
 
 		output, err := utils.ReadFileContent(nodeLog)
 		if err != nil {
 			return err
 		}
 
-		collector.data["nodeLog"] = output
-
+		collector.data[normalizedNodeLog] = output
 	}
 
 	return nil

--- a/pkg/collector/nodelogs_collector_test.go
+++ b/pkg/collector/nodelogs_collector_test.go
@@ -7,11 +7,14 @@ import (
 )
 
 func TestNodeLogsCollector(t *testing.T) {
-	file1 := "/var/log/cloud-init.log"
-	file1Key := "var_log_cloud-init.log"
+	// TODO: Avoid using real files for testing. These are chosen because they happen to exist in
+	// common Linux distros (including Ubuntu on WSL) as well as the Ubuntu GitHub workflow host,
+	// but they won't exist in every environment we might wish to run tests.
+	file1 := "/var/log/alternatives.log"
+	file1Key := "var_log_alternatives.log"
 
-	file2 := "/var/log/dockerd.log"
-	file2Key := "var_log_dockerd.log"
+	file2 := "/var/log/dpkg.log"
+	file2Key := "var_log_dpkg.log"
 
 	tests := []struct {
 		name          string

--- a/pkg/collector/nodelogs_collector_test.go
+++ b/pkg/collector/nodelogs_collector_test.go
@@ -1,20 +1,27 @@
 package collector
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
 
 func TestNodeLogsCollector(t *testing.T) {
+	file1 := "/var/log/cloud-init.log"
+	file1Key := "var_log_cloud-init.log"
+
+	file2 := "/var/log/dockerd.log"
+	file2Key := "var_log_dockerd.log"
+
 	tests := []struct {
 		name          string
-		want          int
+		wantKeys      []string
 		wantErr       bool
 		collectorName string
 	}{
 		{
 			name:          "get node logs",
-			want:          1,
+			wantKeys:      []string{file1Key, file2Key},
 			wantErr:       false,
 			collectorName: "nodelogs",
 		},
@@ -22,7 +29,7 @@ func TestNodeLogsCollector(t *testing.T) {
 
 	c := NewNodeLogsCollector()
 
-	if err := os.Setenv("DIAGNOSTIC_NODELOGS_LIST", "/var/log/cloud-init.log"); err != nil {
+	if err := os.Setenv("DIAGNOSTIC_NODELOGS_LIST", fmt.Sprintf("%s %s", file1, file2)); err != nil {
 		t.Fatalf("Setenv: %v", err)
 	}
 
@@ -33,10 +40,17 @@ func TestNodeLogsCollector(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Collect() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			raw := c.GetData()
 
-			if len(raw) < tt.want {
-				t.Errorf("len(GetData()) = %v, want %v", len(raw), tt.want)
+			dataItems := c.GetData()
+			if len(dataItems) != len(tt.wantKeys) {
+				t.Errorf("len(GetData()) = %v, want %v", len(dataItems), len(tt.wantKeys))
+			}
+
+			for _, fileKey := range tt.wantKeys {
+				_, ok := dataItems[fileKey]
+				if !ok {
+					t.Errorf("Missing file key %s", fileKey)
+				}
 			}
 
 			name := c.GetName()


### PR DESCRIPTION
Addresses #158 - this creates a new key for each log file (sanitized by replacing '/' with '_') rather than writing every file to the same key.