### PR TITLE
Use client-go for OSM collector

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -57,7 +57,7 @@ func main() {
 		collector.NewIPTablesCollector(runtimeInfo),
 		collector.NewKubeObjectsCollector(config, runtimeInfo),
 		collector.NewNodeLogsCollector(runtimeInfo, fileContentReader),
-		collector.NewOsmCollector(runtimeInfo),
+		collector.NewOsmCollector(config, runtimeInfo),
 		collector.NewPDBCollector(config, runtimeInfo),
 		collector.NewPodsContainerLogsCollector(config, runtimeInfo),
 		collector.NewSmiCollector(runtimeInfo),

--- a/pkg/collector/osm_collector.go
+++ b/pkg/collector/osm_collector.go
@@ -1,25 +1,44 @@
 package collector
 
 import (
+	"bufio"
+	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/Azure/aks-periscope/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 )
 
 // OsmCollector defines an OSM Collector struct
 type OsmCollector struct {
-	data        map[string]string
-	runtimeInfo *utils.RuntimeInfo
+	data          map[string]string
+	kubeconfig    *rest.Config
+	commandRunner *utils.KubeCommandRunner
+	runtimeInfo   *utils.RuntimeInfo
 }
 
 // NewOsmCollector is a constructor
-func NewOsmCollector(runtimeInfo *utils.RuntimeInfo) *OsmCollector {
+func NewOsmCollector(config *rest.Config, runtimeInfo *utils.RuntimeInfo) *OsmCollector {
 	return &OsmCollector{
-		data:        make(map[string]string),
-		runtimeInfo: runtimeInfo,
+		data:          make(map[string]string),
+		kubeconfig:    config,
+		commandRunner: utils.NewKubeCommandRunner(config),
+		runtimeInfo:   runtimeInfo,
 	}
 }
 
@@ -43,41 +62,61 @@ func (collector *OsmCollector) CheckSupported() error {
 
 // Collect implements the interface method
 func (collector *OsmCollector) Collect() error {
-	// Get all OSM deployments in order to collect information for various resources across all meshes in the cluster
-	meshList, err := utils.GetResourceList([]string{"get", "deployments", "--all-namespaces", "-l", "app=osm-controller", "-o", "jsonpath={..meshName}"}, " ")
+	clientset, err := kubernetes.NewForConfig(collector.kubeconfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting access to K8S failed: %w", err)
 	}
 
-	for _, meshName := range meshList {
-		monitoredNamespaces, err := utils.GetResourceList([]string{"get", "namespaces", "--all-namespaces", "-l", "openservicemesh.io/monitored-by=" + meshName, "-o", "jsonpath={..name}"}, " ")
-		if err != nil {
-			log.Printf("Failed to find any namespaces monitored by OSM named '%s': %+v\n", meshName, err)
-		}
-		controllerNamespaces, err := utils.GetResourceList([]string{"get", "deployments", "--all-namespaces", "-l", "app=osm-controller,meshName=" + meshName, "-o", "jsonpath={..metadata.namespace}"}, " ")
-		if err != nil {
-			log.Printf("Failed to find controller namespace(s) for OSM named '%s': %+v\n", meshName, err)
-		}
-		collector.callNamespaceCollectors(monitoredNamespaces, controllerNamespaces, meshName)
-		collector.collectGroundTruth(meshName)
+	// Get all OSM deployments in order to collect information for various resources across all meshes in the cluster
+	meshDeploymentList, err := clientset.AppsV1().Deployments("").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=osm-controller",
+	})
+	if err != nil {
+		return fmt.Errorf("error listing deployments in all namespaces: %w", err)
 	}
+
+	for _, deployment := range meshDeploymentList.Items {
+		meshName, found := deployment.Labels["meshName"]
+		if !found {
+			return fmt.Errorf("deployment %s has no 'meshName' label", deployment.Name)
+		}
+
+		monitoredNamespaces := []string{}
+		monitoredNamespaceList, err := clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("openservicemesh.io/monitored-by=%s", meshName),
+		})
+		if err != nil {
+			// If no monitored namespaces are found, just log and continue - this is not an error.
+			if k8sErrors.IsNotFound(err) {
+				log.Printf("Failed to find any namespaces monitored by OSM named '%s'\n", meshName)
+			}
+			return fmt.Errorf("error listing namespaces monitored by OSM named %s: %w", meshName, err)
+		} else {
+			for _, namespace := range monitoredNamespaceList.Items {
+				monitoredNamespaces = append(monitoredNamespaces, namespace.Name)
+			}
+		}
+
+		collector.callNamespaceCollectors(clientset, monitoredNamespaces, deployment.Namespace, meshName)
+		collector.collectGroundTruth(clientset, meshName)
+	}
+
 	return nil
 }
 
 // callNamespaceCollectors calls functions to collect data for osm-controller namespace and namespaces monitored by a given mesh
-func (collector *OsmCollector) callNamespaceCollectors(monitoredNamespaces []string, controllerNamespaces []string, meshName string) {
+func (collector *OsmCollector) callNamespaceCollectors(clientset *kubernetes.Clientset, monitoredNamespaces []string, controllerNamespace string, meshName string) {
 	for _, namespace := range monitoredNamespaces {
-		if err := collector.collectDataFromEnvoys(namespace, meshName); err != nil {
+		if err := collector.collectDataFromEnvoys(clientset, namespace, meshName); err != nil {
 			log.Printf("Failed to collect Envoy configs in OSM monitored namespace %s: %+v", namespace, err)
 		}
 		collector.collectNamespaceResources(namespace, meshName)
 	}
-	for _, namespace := range controllerNamespaces {
-		if err := collector.collectPodLogs(namespace, meshName); err != nil {
-			log.Printf("Failed to collect pod logs for controller namespace %s: %+v", namespace, err)
-		}
-		collector.collectNamespaceResources(namespace, meshName)
+
+	if err := collector.collectPodLogs(clientset, controllerNamespace, meshName); err != nil {
+		log.Printf("Failed to collect pod logs for controller namespace %s: %+v", controllerNamespace, err)
 	}
+	collector.collectNamespaceResources(controllerNamespace, meshName)
 }
 
 // collectNamespaceResources collects information about general resources in a given namespace
@@ -86,201 +125,279 @@ func (collector *OsmCollector) collectNamespaceResources(namespace string, meshN
 		log.Printf("Failed to collect pod configs for ns %s: %+v", namespace, err)
 	}
 
-	metadata, err := utils.RunCommandOnContainer("kubectl", "get", "namespaces", namespace, "-o", "jsonpath={..metadata}", "-o", "json")
+	key := fmt.Sprintf("%s/%s_%s", meshName, namespace, "metadata")
+	value, err := collector.commandRunner.GetJsonObjectOutput(&schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}, "", namespace)
 	if err != nil {
-		metadata = fmt.Sprintf("Failed to collect metadata for namespace %s: %v", namespace, err)
-		log.Print(metadata)
+		value = fmt.Sprintf("Failed to collect metadata for namespace %s: %+v\n", namespace, err)
+		log.Print(value)
+	}
+	collector.data[key] = value
+
+	queryDefinitions := []struct {
+		collectorKey string
+		schema.GroupVersionResource
+		asJson bool
+	}{
+		{collectorKey: "services_list", GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}, asJson: false},
+		{collectorKey: "services", GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}, asJson: true},
+		{collectorKey: "endpoints_list", GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"}, asJson: false},
+		{collectorKey: "endpoints", GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"}, asJson: true},
+		{collectorKey: "configmaps_list", GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, asJson: false},
+		{collectorKey: "configmaps", GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, asJson: true},
+		{collectorKey: "ingresses_list", GroupVersionResource: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}, asJson: false},
+		{collectorKey: "ingresses", GroupVersionResource: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}, asJson: true},
+		{collectorKey: "service_accounts_list", GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}, asJson: false},
+		{collectorKey: "service_accounts", GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}, asJson: true},
+		{collectorKey: "pods_list", GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, asJson: false},
 	}
 
-	servicesList, err := utils.RunCommandOnContainer("kubectl", "get", "services", "-n", namespace, "-o", "wide")
-	if err != nil {
-		servicesList = fmt.Sprintf("Failed to collect services for namespace %s: %v", namespace, err)
-		log.Print(servicesList)
+	for _, defn := range queryDefinitions {
+		key = fmt.Sprintf("%s/%s_%s", meshName, namespace, defn.collectorKey)
+		listOptions := &metav1.ListOptions{}
+		if defn.asJson {
+			value, err = collector.commandRunner.GetJsonListOutput(&defn.GroupVersionResource, namespace, listOptions)
+		} else {
+			value, err = collector.commandRunner.GetTableOutput(&defn.GroupVersionResource, namespace, listOptions, &printers.PrintOptions{Wide: true})
+		}
+		if err != nil {
+			value = fmt.Sprintf("Failed to collect %s for namespace %s: %+v\n", defn.GroupVersionResource.Resource, namespace, err)
+			log.Print(value)
+		}
+		collector.data[key] = value
 	}
-
-	services, err := utils.RunCommandOnContainer("kubectl", "get", "services", "-n", namespace, "-o", "json")
-	if err != nil {
-		services = fmt.Sprintf("Failed to collect services for namespace %s: %v", namespace, err)
-		log.Print(services)
-	}
-
-	endpointList, err := utils.RunCommandOnContainer("kubectl", "get", "endpoints", "-n", namespace, "-o", "wide")
-	if err != nil {
-		endpointList = fmt.Sprintf("Failed to collect endpoints for namespace %s: %v", namespace, err)
-		log.Print(endpointList)
-	}
-
-	endpoints, err := utils.RunCommandOnContainer("kubectl", "get", "endpoints", "-n", namespace, "-o", "json")
-	if err != nil {
-		endpoints = fmt.Sprintf("Failed to collect endpoints for namespace %s: %v", namespace, err)
-		log.Print(endpoints)
-	}
-
-	configmapsList, err := utils.RunCommandOnContainer("kubectl", "get", "configmaps", "-n", namespace, "-o", "wide")
-	if err != nil {
-		configmapsList = fmt.Sprintf("Failed to collect configmaps for namespace %s: %v", namespace, err)
-		log.Print(configmapsList)
-	}
-
-	configmaps, err := utils.RunCommandOnContainer("kubectl", "get", "configmaps", "-n", namespace, "-o", "json")
-	if err != nil {
-		configmaps = fmt.Sprintf("Failed to collect configmaps for namespace %s: %v", namespace, err)
-		log.Print(configmaps)
-	}
-
-	ingressList, err := utils.RunCommandOnContainer("kubectl", "get", "ingresses", "-n", namespace, "-o", "wide")
-	if err != nil {
-		ingressList = fmt.Sprintf("Failed to collect ingresses for namespace %s: %v", namespace, err)
-		log.Print(ingressList)
-	}
-
-	ingresses, err := utils.RunCommandOnContainer("kubectl", "get", "ingresses", "-n", namespace, "-o", "json")
-	if err != nil {
-		ingresses = fmt.Sprintf("Failed to collect ingresses for namespace %s: %v", namespace, err)
-		log.Print(ingresses)
-	}
-
-	svcAccountList, err := utils.RunCommandOnContainer("kubectl", "get", "serviceaccounts", "-n", namespace, "-o", "wide")
-	if err != nil {
-		svcAccountList = fmt.Sprintf("Failed to collect service accounts for namespace %s: %v", namespace, err)
-		log.Print(svcAccountList)
-	}
-
-	svcAccounts, err := utils.RunCommandOnContainer("kubectl", "get", "serviceaccounts", "-n", namespace, "-o", "json")
-	if err != nil {
-		svcAccounts = fmt.Sprintf("Failed to collect service accounts for namespace %s: %v", namespace, err)
-		log.Print(svcAccounts)
-	}
-
-	podList, err := utils.RunCommandOnContainer("kubectl", "get", "pods", "-n", namespace, "-o", "wide")
-	if err != nil {
-		podList = fmt.Sprintf("Failed to collect pod list for namespace %s: %v", namespace, err)
-		log.Print(podList)
-	}
-	filePath := meshName + "/" + namespace
-	collector.data[filePath+"_metadata"] = metadata
-	collector.data[filePath+"_services_list"] = servicesList
-	collector.data[filePath+"_services"] = services
-	collector.data[filePath+"_endpoints_list"] = endpointList
-	collector.data[filePath+"_endpoints"] = endpoints
-	collector.data[filePath+"_configmaps_list"] = configmapsList
-	collector.data[filePath+"_configmaps"] = configmaps
-	collector.data[filePath+"_ingresses_list"] = ingressList
-	collector.data[filePath+"_ingresses"] = ingresses
-	collector.data[filePath+"_service_accounts_list"] = svcAccountList
-	collector.data[filePath+"_service_accounts"] = svcAccounts
-	collector.data[filePath+"_pods_list"] = podList
 }
 
 // collectPodConfigs collects configs for pods in given namespace
 func (collector *OsmCollector) collectPodConfigs(namespace string, meshName string) error {
-	pods, err := utils.GetResourceList([]string{"get", "pods", "-n", namespace, "-o", "jsonpath={..metadata.name}"}, " ")
+	listOptions := &metav1.ListOptions{}
+	list, err := collector.commandRunner.GetUnstructuredList(&schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, namespace, listOptions)
 	if err != nil {
 		return err
 	}
-
-	for _, podName := range pods {
-		output, err := utils.RunCommandOnContainer("kubectl", "get", "pods", "-n", namespace, podName, "-o", "json")
+	for _, item := range list.Items {
+		podName := item.GetName()
+		value, err := collector.commandRunner.PrintAsJson(&item)
 		if err != nil {
-			output = fmt.Sprintf("Failed to collect config for pod %s in OSM monitored namespace %s: %v", podName, namespace, err)
-			log.Print(output)
+			value := fmt.Sprintf("Failed to read JSON for pod %s in %s: %+v\n", podName, namespace, err)
+			log.Print(value)
 		}
-		filePath := meshName + "/" + podName + "_podConfig"
-		collector.data[filePath] = output
+		key := fmt.Sprintf("%s/%s_podConfig", meshName, podName)
+		collector.data[key] = value
 	}
-
 	return nil
 }
 
 // collectDataFromEnvoys collects Envoy proxy config for pods in monitored namespace: port-forward and curl config dump
-func (collector *OsmCollector) collectDataFromEnvoys(namespace string, meshName string) error {
-	pods, err := utils.GetResourceList([]string{"get", "pods", "-n", namespace, "-o", "jsonpath={..metadata.name}"}, " ")
+func (collector *OsmCollector) collectDataFromEnvoys(clientset *kubernetes.Clientset, namespace string, meshName string) error {
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
-	for _, podName := range pods {
-		pid, err := utils.RunBackgroundCommand("kubectl", "port-forward", podName, "-n", namespace, "15000:15000")
-		if err != nil {
-			log.Printf("Failed to collect Envoy config for pod %s in OSM monitored namespace %s: %+v", podName, namespace, err)
-			continue
-		}
 
-		envoyQueries := [5]string{"config_dump", "clusters", "listeners", "ready", "stats"}
-		for _, query := range envoyQueries {
-			responseBody, err := utils.GetUrlWithRetries("http://localhost:15000/"+query, 5)
-			if err != nil {
-				log.Printf("Failed to collect Envoy %s for pod %s in OSM monitored namespace %s: %+v", query, podName, namespace, err)
-				continue
-			}
-			// Remove certificate secrets from Envoy config i.e., "inline_bytes" field from response
-			re := regexp.MustCompile("(?m)[\r\n]+^.*inline_bytes.*$")
-			secretRemovedResponse := re.ReplaceAllString(string(responseBody), "---redacted---")
-			filePath := meshName + "/envoy/" + podName + query
-			collector.data[filePath] = secretRemovedResponse
-		}
-		if err = utils.KillProcess(pid); err != nil {
-			log.Printf("Failed to kill process: %+v", err)
-			continue
+	for _, pod := range pods.Items {
+		err = collector.portForwardAndRunEnvoyQueries(meshName, namespace, pod.Name)
+		if err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-// collectPodLogs collects logs of every pod in a given namespace
-func (collector *OsmCollector) collectPodLogs(namespace string, meshName string) error {
-	pods, err := utils.GetResourceList([]string{"get", "pods", "-n", namespace, "-o", "jsonpath={..metadata.name}"}, " ")
+func (collector *OsmCollector) portForwardAndRunEnvoyQueries(meshName, namespace, podName string) error {
+	var buffOut, buffErr bytes.Buffer
+	readyChan := make(chan struct{})
+	stopChan := make(chan struct{}, 1)
+	errorChan := make(chan error)
+	const localPort = 15000
+
+	defer close(stopChan)
+
+	go func() {
+		err := collector.portForward(&portForwardParams{
+			namespace: namespace,
+			podName:   podName,
+			localPort: localPort,
+			podPort:   15000,
+			outStream: bufio.NewWriter(&buffOut),
+			errStream: bufio.NewWriter(&buffErr),
+			readyChan: readyChan,
+			stopChan:  stopChan,
+		})
+		if err != nil {
+			errorChan <- err
+		}
+	}()
+
+	select {
+	case err := <-errorChan:
+		return err
+	case <-readyChan:
+		collector.runEnvoyQueries(meshName, namespace, podName, localPort)
+	}
+
+	return nil
+}
+
+func (collector *OsmCollector) runEnvoyQueries(meshName, namespace, podName string, localPort int) {
+	envoyQueries := [5]string{"config_dump", "clusters", "listeners", "ready", "stats"}
+	for _, query := range envoyQueries {
+		queryUrl := fmt.Sprintf("http://localhost:%d/%s", localPort, query)
+		responseBody, err := utils.GetUrlWithRetries(queryUrl, 5)
+		if err != nil {
+			log.Printf("Failed to collect Envoy %s for pod %s in OSM monitored namespace %s: %+v", query, podName, namespace, err)
+			continue
+		}
+		// Remove certificate secrets from Envoy config i.e., "inline_bytes" field from response
+		re := regexp.MustCompile("(?m)[\r\n]+^.*inline_bytes.*$")
+		secretRemovedResponse := re.ReplaceAllString(string(responseBody), "---redacted---")
+
+		key := fmt.Sprintf("%s/envoy/%s%s", meshName, podName, query)
+		collector.data[key] = secretRemovedResponse
+	}
+}
+
+type portForwardParams struct {
+	namespace string
+	podName   string
+	localPort int
+	podPort   int
+	outStream io.Writer
+	errStream io.Writer
+	readyChan chan struct{}
+	stopChan  <-chan struct{}
+}
+
+func (collector *OsmCollector) portForward(params *portForwardParams) error {
+	endpoint, err := url.Parse(collector.kubeconfig.Host)
+	if err != nil {
+		return fmt.Errorf("error parsing host URL (%s): %w", collector.kubeconfig.Host, err)
+	}
+	endpoint.Path = fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", params.namespace, params.podName)
+
+	transport, upgrader, err := spdy.RoundTripperFor(collector.kubeconfig)
 	if err != nil {
 		return err
 	}
-	for _, podName := range pods {
-		output, err := utils.RunCommandOnContainer("kubectl", "logs", "-n", namespace, podName)
+
+	portMap := fmt.Sprintf("%d:%d", params.localPort, params.podPort)
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, endpoint)
+	fw, err := portforward.New(dialer, []string{portMap}, params.stopChan, params.readyChan, params.outStream, params.errStream)
+	if err != nil {
+		return err
+	}
+	return fw.ForwardPorts()
+}
+
+// collectPodLogs collects logs of every pod in a given namespace
+func (collector *OsmCollector) collectPodLogs(clientset *kubernetes.Clientset, namespace string, meshName string) error {
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods.Items {
+		output, err := collector.getSinglePodLogs(clientset, namespace, pod.Name)
 		if err != nil {
-			output = fmt.Sprintf("Failed to collect logs for pod %s: %+v", podName, err)
+			output = fmt.Sprintf("Failed to collect logs for pod %s: %+v\n", pod.Name, err)
 			log.Print(output)
 		}
-		filePath := meshName + "/" + podName + "_podLogs"
+		filePath := meshName + "/" + pod.Name + "_podLogs"
 		collector.data[filePath] = output
 	}
 	return nil
 }
 
+func (collector *OsmCollector) getSinglePodLogs(clientset *kubernetes.Clientset, namespace, podName string) (string, error) {
+	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	podLogs, err := req.Stream(context.Background())
+	if err != nil {
+		return "", fmt.Errorf("error getting log stream for %s/%s", namespace, podName)
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", fmt.Errorf("error reading log stream for %s/%s", namespace, podName)
+	}
+	return buf.String(), nil
+}
+
 // collectGroundTruth collects ground truth on resources in given mesh
-func (collector *OsmCollector) collectGroundTruth(meshName string) {
-	allResourcesList, err := utils.RunCommandOnContainer("kubectl", "get", "all", "--all-namespaces", "-l", "app.kubernetes.io/instance="+meshName, "-o", "wide")
-	if err != nil {
-		allResourcesList = fmt.Sprintf("Failed to collect all resources list for mesh %s: %v", meshName, err)
-		log.Print(allResourcesList)
+func (collector *OsmCollector) collectGroundTruth(clientset *kubernetes.Clientset, meshName string) {
+	type groupVersionResourceKind struct {
+		schema.GroupVersionResource
+		kind string
 	}
 
-	allResourcesConfigs, err := utils.RunCommandOnContainer("kubectl", "get", "all", "--all-namespaces", "-l", "app.kubernetes.io/instance="+meshName, "-o", "json")
-	if err != nil {
-		allResourcesConfigs = fmt.Sprintf("Failed to collect all resources configs for mesh %s: %v", meshName, err)
-		log.Print(allResourcesConfigs)
+	gvrksForGetAll := []groupVersionResourceKind{
+		{GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, kind: "Pod"},
+		{GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}, kind: "Service"},
+		{GroupVersionResource: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}, kind: "DaemonSet"},
+		{GroupVersionResource: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, kind: "Deployment"},
+		{GroupVersionResource: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}, kind: "ReplicaSet"},
+		{GroupVersionResource: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}, kind: "StatefulSet"},
+		{GroupVersionResource: schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}, kind: "Job"},
+		{GroupVersionResource: schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"}, kind: "CronJob"},
 	}
 
-	mutationWebhookConfig, err := utils.RunCommandOnContainer("kubectl", "get", "MutatingWebhookConfiguration", "--all-namespaces", "-l", "app.kubernetes.io/instance="+meshName, "-o", "json")
-	if err != nil {
-		mutationWebhookConfig = fmt.Sprintf("Failed to collect mutating webhook config for mesh %s: %v", meshName, err)
-		log.Print(mutationWebhookConfig)
+	gvrksForMutatingWebhookConfig := []groupVersionResourceKind{
+		{GroupVersionResource: schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingwebhookconfigurations"}, kind: "MutatingWebhookConfiguration"},
 	}
 
-	validatingWebhookConfig, err := utils.RunCommandOnContainer("kubectl", "get", "ValidatingWebhookConfiguration", "--all-namespaces", "-l", "app.kubernetes.io/instance="+meshName, "-o", "json")
-	if err != nil {
-		validatingWebhookConfig = fmt.Sprintf("Failed to collect validating webhook config for mesh %s: %v", meshName, err)
-		log.Print(validatingWebhookConfig)
+	gvrksForValidatingWebhookConfig := []groupVersionResourceKind{
+		{GroupVersionResource: schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"}, kind: "ValidatingWebhookConfiguration"},
 	}
 
-	meshConfig, err := utils.RunCommandOnContainer("kubectl", "get", "meshconfigs", "--all-namespaces", "-o", "json")
+	gvrForMeshConfig, err := collector.commandRunner.GetGVRForCRD("meshconfigs.config.openservicemesh.io")
 	if err != nil {
-		meshConfig = fmt.Sprintf("Failed to collect meshconfigs for mesh %s: %v", meshName, err)
-		log.Print(meshConfig)
+		log.Printf("Failed to read MeshConfig CRD: %v", err)
+		return
 	}
-	filePath := meshName + "/control_plane"
-	collector.data[filePath+"/all_resources_list"] = allResourcesList
-	collector.data[filePath+"/all_resources_configs"] = allResourcesConfigs
-	collector.data[filePath+"/mutating_webhook_configurations"] = mutationWebhookConfig
-	collector.data[filePath+"/validating_webhook_configurations"] = validatingWebhookConfig
-	collector.data[filePath+"/mesh_configs"] = meshConfig
+
+	gvrksForMeshConfig := []groupVersionResourceKind{
+		{GroupVersionResource: *gvrForMeshConfig, kind: "MeshConfig"},
+	}
+
+	meshLabelSelector := fmt.Sprintf("app.kubernetes.io/instance=%s", meshName)
+	queryDefinitions := []struct {
+		collectorKey  string
+		gvrks         []groupVersionResourceKind
+		labelSelector string
+		asJson        bool
+	}{
+		{collectorKey: "all_resources_list", gvrks: gvrksForGetAll, labelSelector: meshLabelSelector, asJson: false},
+		{collectorKey: "all_resources_configs", gvrks: gvrksForGetAll, labelSelector: meshLabelSelector, asJson: true},
+		{collectorKey: "mutating_webhook_configurations", gvrks: gvrksForMutatingWebhookConfig, labelSelector: meshLabelSelector, asJson: true},
+		{collectorKey: "validating_webhook_configurations", gvrks: gvrksForValidatingWebhookConfig, labelSelector: meshLabelSelector, asJson: true},
+		{collectorKey: "mesh_configs", gvrks: gvrksForMeshConfig, labelSelector: "", asJson: true},
+	}
+
+	for _, defn := range queryDefinitions {
+		var sb strings.Builder
+		for _, gvrk := range defn.gvrks {
+			listOptions := &metav1.ListOptions{LabelSelector: defn.labelSelector}
+			var output string
+			if defn.asJson {
+				output, err = collector.commandRunner.GetJsonListOutput(&gvrk.GroupVersionResource, "", listOptions)
+			} else {
+				output, err = collector.commandRunner.GetTableOutput(&gvrk.GroupVersionResource, "", listOptions, &printers.PrintOptions{
+					Wide:          true,
+					WithNamespace: true,
+					WithKind:      true,
+					Kind:          schema.GroupKind{Group: gvrk.GroupVersionResource.Group, Kind: gvrk.kind},
+				})
+			}
+			if err != nil {
+				output = fmt.Sprintf("Error retrieving %s for all namespaces for mesh %s: %+v\n", gvrk.kind, meshName, err)
+				log.Print(output)
+			}
+			sb.WriteString(output)
+			sb.WriteString("\n")
+		}
+		key := fmt.Sprintf("%s/control_plane/%s", meshName, defn.collectorKey)
+		collector.data[key] = sb.String()
+	}
 }
 
 func (collector *OsmCollector) GetData() map[string]string {

--- a/pkg/collector/osm_collector.go
+++ b/pkg/collector/osm_collector.go
@@ -391,7 +391,7 @@ func (collector *OsmCollector) collectGroundTruth(clientset *kubernetes.Clientse
 				})
 			}
 			if err != nil {
-				output = fmt.Sprintf("Error retrieving %s for all namespaces for mesh %s: %+v\n", gvrk.kind, meshName, err)
+				output = fmt.Sprintf("Error retrieving %s for mesh %s: %+v\n", gvrk.kind, meshName, err)
 				log.Print(output)
 			}
 			sb.WriteString(output)

--- a/pkg/collector/osm_collector_test.go
+++ b/pkg/collector/osm_collector_test.go
@@ -17,7 +17,7 @@ import (
 func TestOsmCollectorGetName(t *testing.T) {
 	const expectedName = "osm"
 
-	c := NewOsmCollector(nil)
+	c := NewOsmCollector(nil, nil)
 	actualName := c.GetName()
 	if actualName != expectedName {
 		t.Errorf("unexpected name: expected %s, found %s", expectedName, actualName)
@@ -56,7 +56,7 @@ func TestOsmCollectorCheckSupported(t *testing.T) {
 			OSIdentifier:  tt.osIdentifier,
 			CollectorList: tt.collectors,
 		}
-		c := NewOsmCollector(runtimeInfo)
+		c := NewOsmCollector(nil, runtimeInfo)
 		err := c.CheckSupported()
 		if (err != nil) != tt.wantErr {
 			t.Errorf("CheckSupported() for %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
@@ -111,7 +111,7 @@ func TestOsmCollectorCollect(t *testing.T) {
 		CollectorList: []string{"OSM"},
 	}
 
-	c := NewOsmCollector(runtimeInfo)
+	c := NewOsmCollector(fixture.ClientConfig, runtimeInfo)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/utils/kubeCommandRunner.go
+++ b/pkg/utils/kubeCommandRunner.go
@@ -1,0 +1,312 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/rest"
+)
+
+// KubeCommandRunner replicates some of the functionality provided by the kubectl binary.
+// This uses the `Unstructured` package (https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured)
+// to work with API resources.
+// That decision means we sacrifice strong typing to get more straightforward serialization, fewer package
+// dependencies, and better ability to handle resource version changes over time.
+type KubeCommandRunner struct {
+	kubeconfig *rest.Config
+}
+
+func NewKubeCommandRunner(config *rest.Config) *KubeCommandRunner {
+	return &KubeCommandRunner{
+		kubeconfig: config,
+	}
+}
+
+// GetTableOutput replicates 'kubectl get [kind] -o [table|wide]'.
+func (runner *KubeCommandRunner) GetTableOutput(gvr *schema.GroupVersionResource, namespace string, listOptions *metav1.ListOptions, printOptions *printers.PrintOptions) (string, error) {
+	table, err := runner.GetUnstructuredTable(gvr, namespace, listOptions)
+	if err != nil {
+		return "", fmt.Errorf("error requesting table for %s in %s: %w", gvr.String(), namespace, err)
+	}
+
+	output, err := runner.PrintAsTable(table, printOptions)
+	if err != nil {
+		return "", fmt.Errorf("error printing %s in %s as table: %w", gvr.String(), namespace, err)
+	}
+
+	return output, nil
+}
+
+// GetJsonListOutput replicates 'kubectl get [kind] -o json'.
+func (runner *KubeCommandRunner) GetJsonListOutput(gvr *schema.GroupVersionResource, namespace string, listOptions *metav1.ListOptions) (string, error) {
+	list, err := runner.GetUnstructuredList(gvr, namespace, listOptions)
+	if err != nil {
+		return "", fmt.Errorf("error requesting all %s in %s: %w", gvr.String(), namespace, err)
+	}
+
+	output, err := runner.PrintAsJson(list)
+	if err != nil {
+		return "", fmt.Errorf("error printing %s in %s as JSON: %w", gvr.String(), namespace, err)
+	}
+
+	return output, nil
+}
+
+// GetYamlListOutput replicates 'kubectl get [kind] -o yaml'.
+func (runner *KubeCommandRunner) GetYamlListOutput(gvr *schema.GroupVersionResource, namespace string, listOptions *metav1.ListOptions) (string, error) {
+	list, err := runner.GetUnstructuredList(gvr, namespace, listOptions)
+	if err != nil {
+		return "", fmt.Errorf("error requesting all %s in %s: %w", gvr.String(), namespace, err)
+	}
+
+	output, err := runner.PrintAsYaml(list)
+	if err != nil {
+		return "", fmt.Errorf("error printing %s in %s as YAML: %w", gvr.String(), namespace, err)
+	}
+
+	return output, nil
+}
+
+// GetJsonObjectOutput replicates 'kubectl get [kind] [name] -o json'.
+func (runner *KubeCommandRunner) GetJsonObjectOutput(gvr *schema.GroupVersionResource, namespace, name string) (string, error) {
+	obj, err := runner.GetUnstructuredItem(gvr, namespace, name)
+	if err != nil {
+		return "", fmt.Errorf("error requesting %s %s in %s: %w", gvr.String(), name, namespace, err)
+	}
+
+	output, err := runner.PrintAsJson(obj)
+	if err != nil {
+		return "", fmt.Errorf("error printing %s %s in %s as JSON: %w", gvr.String(), name, namespace, err)
+	}
+
+	return output, nil
+}
+
+// GetYamlObjectOutput replicates 'kubectl get [kind] [name] -o yaml'.
+func (runner *KubeCommandRunner) GetYamlObjectOutput(gvr *schema.GroupVersionResource, namespace, name string) (string, error) {
+	obj, err := runner.GetUnstructuredItem(gvr, namespace, name)
+	if err != nil {
+		return "", fmt.Errorf("error requesting %s %s in %s: %w", gvr.String(), name, namespace, err)
+	}
+
+	output, err := runner.PrintAsYaml(obj)
+	if err != nil {
+		return "", fmt.Errorf("error printing %s %s in %s as YAML: %w", gvr.String(), name, namespace, err)
+	}
+
+	return output, nil
+}
+
+// GetUnstructuredList gets the API response to a List request in Unstructured form.
+func (runner *KubeCommandRunner) GetUnstructuredList(gvr *schema.GroupVersionResource, namespace string, options *metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	request, err := runner.getUnstructuredRequest(gvr, false)
+	if err != nil {
+		return nil, fmt.Errorf("error getting request for JSON: %w", err)
+	}
+
+	request = request.NamespaceIfScoped(namespace, namespace != "").VersionedParams(options, metav1.ParameterCodec)
+
+	obj, err := request.Do(context.Background()).Get()
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	return obj.(*unstructured.UnstructuredList), nil
+}
+
+// GetUnstructuredTable gets the API response to a List request for a server-generated table, in Unstructured form.
+func (runner *KubeCommandRunner) GetUnstructuredTable(gvr *schema.GroupVersionResource, namespace string, options *metav1.ListOptions) (*unstructured.Unstructured, error) {
+	request, err := runner.getUnstructuredRequest(gvr, true)
+	if err != nil {
+		return nil, fmt.Errorf("error getting request for table: %w", err)
+	}
+
+	request = request.NamespaceIfScoped(namespace, namespace != "").VersionedParams(options, metav1.ParameterCodec)
+
+	obj, err := request.Do(context.Background()).Get()
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	return obj.(*unstructured.Unstructured), nil
+}
+
+// GetUnstructuredItem gets the API response to a Get request in Unstructured form.
+func (runner *KubeCommandRunner) GetUnstructuredItem(gvr *schema.GroupVersionResource, namespace string, name string) (*unstructured.Unstructured, error) {
+	request, err := runner.getUnstructuredRequest(gvr, false)
+	if err != nil {
+		return nil, fmt.Errorf("error getting request for JSON: %w", err)
+	}
+
+	request = request.NamespaceIfScoped(namespace, namespace != "").VersionedParams(&metav1.GetOptions{}, metav1.ParameterCodec).Name(name)
+
+	obj, err := request.Do(context.Background()).Get()
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	return obj.(*unstructured.Unstructured), nil
+}
+
+// PrintAsJson takes the Unstructured representation or one or more resources and serializes them as formatted JSON.
+// If the input is a List type, it replaces the Kind/APIVersion with a generic 'List' Kind (as kubectl does).
+func (runner *KubeCommandRunner) PrintAsJson(obj runtime.Unstructured) (string, error) {
+	return runner.serialize(obj, &printers.JSONPrinter{})
+}
+
+// PrintAsYaml takes the Unstructured representation or one or more resources and serializes them as formatted YAML.
+// If the input is a List type, it replaces the Kind/APIVersion with a generic 'List' Kind (as kubectl does).
+func (runner *KubeCommandRunner) PrintAsYaml(obj runtime.Unstructured) (string, error) {
+	return runner.serialize(obj, &printers.YAMLPrinter{})
+}
+
+func (runner *KubeCommandRunner) serialize(obj runtime.Unstructured, printer printers.ResourcePrinter) (string, error) {
+	list, isList := obj.(*unstructured.UnstructuredList)
+	if isList {
+		list.SetKind("List")
+		list.SetAPIVersion("v1")
+		list.SetResourceVersion("")
+		list.SetSelfLink("")
+	}
+
+	omitManagedFieldsPrinter := printers.OmitManagedFieldsPrinter{Delegate: printer}
+
+	var buf bytes.Buffer
+	if err := omitManagedFieldsPrinter.PrintObj(obj, &buf); err != nil {
+		return "", fmt.Errorf("error serializing resource: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// PrintAsTable takes the Unstructured representation of a table (as returned from the API), and outputs it as a
+// human-readable table.
+func (runner *KubeCommandRunner) PrintAsTable(obj runtime.Unstructured, printOptions *printers.PrintOptions) (string, error) {
+	table := &metav1.Table{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), table); err != nil {
+		return "", fmt.Errorf("error converting unstructured data to table: %w", err)
+	}
+
+	printer := printers.NewTablePrinter(*printOptions)
+
+	var buf bytes.Buffer
+	if err := printer.PrintObj(table, &buf); err != nil {
+		return "", fmt.Errorf("error printing resource as table: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+func (runner *KubeCommandRunner) getUnstructuredRequest(gvr *schema.GroupVersionResource, asTable bool) (*rest.Request, error) {
+	// Normally, to get Unstructured data you'd use the 'dynamic' client (https://pkg.go.dev/k8s.io/client-go/dynamic).
+	// However, to request table-formatted data from the API, you need to set the Accept header on the request.
+	// AFAICT, the dynamic client doesn't support this, so here we build the request directly.
+	config := rest.CopyConfig(runner.kubeconfig)
+	config.ContentConfig = resource.UnstructuredPlusDefaultContentConfig()
+	gv := gvr.GroupVersion()
+	config.GroupVersion = &gv
+	if len(gv.Group) == 0 {
+		config.APIPath = "/api"
+	} else {
+		config.APIPath = "/apis"
+	}
+
+	var restClient resource.RESTClient
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if asTable {
+		restClient = resource.NewClientWithOptions(restClient, func(req *rest.Request) {
+			req.SetHeader("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io")
+		})
+	}
+
+	return restClient.Get().Resource(gvr.Resource), nil
+}
+
+// For compatibility between K8s versions, we support retrieval of CRDs with newer and older APIVersions.
+// (https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122)
+var crdGvrs = []schema.GroupVersionResource{
+	schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"},
+	schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"},
+}
+
+// GetCRDUnstructuredList reads all the CRDs in the cluster and returns the result as an UnstructuredList.
+func (runner *KubeCommandRunner) GetCRDUnstructuredList() (*unstructured.UnstructuredList, error) {
+	for _, gvr := range crdGvrs {
+		crds, err := runner.GetUnstructuredList(&gvr, "", &metav1.ListOptions{})
+		if err != nil {
+			if k8sErrors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		// Found
+		return crds, nil
+	}
+
+	return nil, errors.New("no CRD resource type found")
+}
+
+// GetGVRForCRD gets the GroupVersionResource for the specified CRD (where Version is the 'storage'
+// version for the resources).
+func (runner *KubeCommandRunner) GetGVRForCRD(crdName string) (*schema.GroupVersionResource, error) {
+	for _, gvr := range crdGvrs {
+		crd, err := runner.GetUnstructuredItem(&gvr, "", crdName)
+		if err != nil {
+			if k8sErrors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		return runner.GetGVRFromCRD(crd)
+	}
+	return nil, fmt.Errorf("crd %s not found", crdName)
+}
+
+// GetGVRFromCRD takes a CRD in Unstructured form and returns the GroupVersionResource for its resources.
+func (runner *KubeCommandRunner) GetGVRFromCRD(crd *unstructured.Unstructured) (*schema.GroupVersionResource, error) {
+	// The name of a CRD is of the form 'resource.group', so that gives us 2/3 of the GVR.
+	name := crd.GetName()
+	groupResource := schema.ParseGroupResource(name)
+
+	// For the version, use the 'storage' version. See:
+	// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#writing-reading-and-updating-versioned-customresourcedefinition-objects
+	versionList, found, err := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	if !found || err != nil {
+		return nil, errors.New("spec.versions not found")
+	}
+	version := ""
+	for _, versionItem := range versionList {
+		versionObj := versionItem.(map[string]interface{})
+		isStorageVersion, found, err := unstructured.NestedBool(versionObj, "storage")
+		if !found || err != nil {
+			return nil, errors.New("spec.versions[].storage not found")
+		}
+
+		if isStorageVersion {
+			version, found, err = unstructured.NestedString(versionObj, "name")
+			if !found || err != nil {
+				return nil, errors.New("spec.versions[].name not found")
+			}
+			break
+		}
+	}
+	if version == "" {
+		return nil, errors.New("no storage version found")
+	}
+
+	gvr := groupResource.WithVersion(version)
+	return &gvr, nil
+}


### PR DESCRIPTION
Addresses #124 

This is to take us one step further towards removing our reliance on the `kubectl` binary and parity between operating systems.

Since almost all the data we collect for OSM and SMI is JSON/YAML/tables, we don't really want or need the strongly-typed kubernetes resource types provided by the client-go library. Instead we use the `Unstructured` package which allows relatively trivial serialization to these formats.

Much of the code that replicates the output of `kubectl` commands is common between OSM and SMI collectors, and has been refactored out into the shared `KubeCommandRunner` type.