### PR TITLE
Remove dependency on kubectl binary

### DIFF
--- a/builder/Dockerfile.linux
+++ b/builder/Dockerfile.linux
@@ -20,11 +20,6 @@ RUN go build ./cmd/aks-periscope
 # Runner
 FROM alpine
 
-RUN apk --no-cache add ca-certificates curl openssl bash
-
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
-
 COPY --from=builder /build/aks-periscope /
 
 ENTRYPOINT ["/aks-periscope"]

--- a/docs/windows-vs-linux.md
+++ b/docs/windows-vs-linux.md
@@ -9,7 +9,6 @@ The following collectors are currently unavailable on Windows:
 - DNS: This relies on `resolv.conf`, which is unavailable in Windows.
 - IPTables: The `iptables` command is not available on Windows.
 - Kubelet: This shows the arguments used to invoke the kubelet process. Windows containers do not support shared process namespaces, and so we cannot see processes on the host node.
-- OSM and SMI: These collectors currently invoke the `kubectl` binary as a shell command, rather than using the cross-platform `client-go` SDK.
 - SystemLogs: This uses `journalctl` to retrieve system logs, which is not available on Windows.
 
 ## Node Logs differences

--- a/pkg/collector/osm_collector.go
+++ b/pkg/collector/osm_collector.go
@@ -47,12 +47,6 @@ func (collector *OsmCollector) GetName() string {
 }
 
 func (collector *OsmCollector) CheckSupported() error {
-	// This is not currently supported on Windows because it launches `kubectl` as a separate process (within GetResourceList).
-	// If/when it is reimplemented using the go client API for k8s, we can re-enable this.
-	if collector.runtimeInfo.OSIdentifier != "linux" {
-		return fmt.Errorf("unsupported OS: %s", collector.runtimeInfo.OSIdentifier)
-	}
-
 	if !utils.Contains(collector.runtimeInfo.CollectorList, "OSM") {
 		return fmt.Errorf("not included because 'OSM' not in COLLECTOR_LIST variable. Included values: %s", strings.Join(collector.runtimeInfo.CollectorList, " "))
 	}

--- a/pkg/collector/osm_collector_test.go
+++ b/pkg/collector/osm_collector_test.go
@@ -26,34 +26,24 @@ func TestOsmCollectorGetName(t *testing.T) {
 
 func TestOsmCollectorCheckSupported(t *testing.T) {
 	tests := []struct {
-		name         string
-		osIdentifier string
-		collectors   []string
-		wantErr      bool
+		name       string
+		collectors []string
+		wantErr    bool
 	}{
 		{
-			name:         "windows",
-			osIdentifier: "windows",
-			collectors:   []string{"OSM"},
-			wantErr:      true,
+			name:       "OSM not included",
+			collectors: []string{"NOT_OSM"},
+			wantErr:    true,
 		},
 		{
-			name:         "linux without OSM included",
-			osIdentifier: "linux",
-			collectors:   []string{"NOT_OSM"},
-			wantErr:      true,
-		},
-		{
-			name:         "linux with OSM included",
-			osIdentifier: "linux",
-			collectors:   []string{"OSM"},
-			wantErr:      false,
+			name:       "OSM included",
+			collectors: []string{"OSM"},
+			wantErr:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		runtimeInfo := &utils.RuntimeInfo{
-			OSIdentifier:  tt.osIdentifier,
 			CollectorList: tt.collectors,
 		}
 		c := NewOsmCollector(nil, runtimeInfo)
@@ -107,7 +97,6 @@ func TestOsmCollectorCollect(t *testing.T) {
 	}
 
 	runtimeInfo := &utils.RuntimeInfo{
-		OSIdentifier:  "linux",
 		CollectorList: []string{"OSM"},
 	}
 

--- a/pkg/collector/smi_collector.go
+++ b/pkg/collector/smi_collector.go
@@ -34,12 +34,6 @@ func (collector *SmiCollector) GetName() string {
 }
 
 func (collector *SmiCollector) CheckSupported() error {
-	// This is not currently supported on Windows because it launches `kubectl` as a separate process (within GetResourceList).
-	// If/when it is reimplemented using the go client API for k8s, we can re-enable this.
-	if collector.runtimeInfo.OSIdentifier != "linux" {
-		return fmt.Errorf("unsupported OS: %s", collector.runtimeInfo.OSIdentifier)
-	}
-
 	if !utils.Contains(collector.runtimeInfo.CollectorList, "OSM") && !utils.Contains(collector.runtimeInfo.CollectorList, "SMI") {
 		return fmt.Errorf("not included because neither 'OSM' or 'SMI' are in COLLECTOR_LIST variable. Included values: %s", strings.Join(collector.runtimeInfo.CollectorList, " "))
 	}

--- a/pkg/collector/smi_collector_test.go
+++ b/pkg/collector/smi_collector_test.go
@@ -23,40 +23,29 @@ func TestSmiCollectorGetName(t *testing.T) {
 
 func TestSmiCollectorCheckSupported(t *testing.T) {
 	tests := []struct {
-		name         string
-		osIdentifier string
-		collectors   []string
-		wantErr      bool
+		name       string
+		collectors []string
+		wantErr    bool
 	}{
 		{
-			name:         "windows",
-			osIdentifier: "windows",
-			collectors:   []string{"SMI"},
-			wantErr:      true,
+			name:       "no OSM or SMI included",
+			collectors: []string{"NOT_OSM", "NOT_SMI"},
+			wantErr:    true,
 		},
 		{
-			name:         "linux without OSM or SMI included",
-			osIdentifier: "linux",
-			collectors:   []string{"NOT_OSM", "NOT_SMI"},
-			wantErr:      true,
+			name:       "only OSM included",
+			collectors: []string{"OSM", "NOT_SMI"},
+			wantErr:    false,
 		},
 		{
-			name:         "linux with OSM included",
-			osIdentifier: "linux",
-			collectors:   []string{"OSM", "NOT_SMI"},
-			wantErr:      false,
-		},
-		{
-			name:         "linux with SMI included",
-			osIdentifier: "linux",
-			collectors:   []string{"NOT_OSM", "SMI"},
-			wantErr:      false,
+			name:       "only SMI included",
+			collectors: []string{"NOT_OSM", "SMI"},
+			wantErr:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		runtimeInfo := &utils.RuntimeInfo{
-			OSIdentifier:  tt.osIdentifier,
 			CollectorList: tt.collectors,
 		}
 		c := NewSmiCollector(nil, runtimeInfo)
@@ -84,7 +73,6 @@ func TestSmiCollectorCollect(t *testing.T) {
 	}
 
 	runtimeInfo := &utils.RuntimeInfo{
-		OSIdentifier:  "linux",
 		CollectorList: []string{"SMI"},
 	}
 

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -200,23 +200,6 @@ func GetCreationTimeStamp(config *restclient.Config) (string, error) {
 	return creationTimeStamp, nil
 }
 
-// GetResourceList gets a list of all resources of given type in a specified namespace
-func GetResourceList(kubeCmds []string, separator string) ([]string, error) {
-	outputStreams, err := RunCommandOnContainerWithOutputStreams("kubectl", kubeCmds...)
-
-	if err != nil {
-		return nil, err
-	}
-
-	resourceList := outputStreams.Stdout
-	// If the resource is not found within the cluster, then log a message and do not return any resources.
-	if len(resourceList) == 0 {
-		return nil, fmt.Errorf("no '%s' resource found in the cluster for given kubectl command", kubeCmds[1])
-	}
-
-	return strings.Split(strings.Trim(resourceList, "\""), separator), nil
-}
-
 func GetPods(clientset *kubernetes.Clientset, namespace string) (*v1.PodList, error) {
 	// Create a pod interface for the given namespace
 	podInterface := clientset.CoreV1().Pods(namespace)


### PR DESCRIPTION
Now that the OSM and SMI collectors are no longer dependent on `kubectl`, we can remove the binary from the Periscope image.

This removes it from the Docker image, along with other unused packages (taking the Linux image size from 161MB to 63MB).

It also updates the OSM and SMI collectors so that they will be enabled on Windows nodes.

To test manually, run Periscope from VS Code after setting the following in `settings.json`:

```json
    "aks.periscope.containerRegistry": "ghcr.io/peterbom",
    "aks.periscope.imageVersion": "0.0.9",
    "aks.periscope.releaseTag": "v0.9",
    "aks.periscope.repoOrg": "peterbom",
```