### PR TITLE
Allow specified resource types and names for kube-objects collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ secretGenerator:
 #   behavior: replace
 #   literals:
 #   - DIAGNOSTIC_CONTAINERLOGS_LIST=kube-system # space-separated namespaces
-#   - DIAGNOSTIC_KUBEOBJECTS_LIST=kube-system/pod kube-system/service kube-system/deployment # space-separated namespace/kind pairs
+#   - DIAGNOSTIC_KUBEOBJECTS_LIST=kube-system/pod kube-system/service kube-system/deployment # space-separated list of namespace/resource-type[/resource]
 #   - DIAGNOSTIC_NODELOGS_LIST_LINUX="/var/log/azure/cluster-provision.log /var/log/cloud-init.log" # space-separated log file locations
 #   - DIAGNOSTIC_NODELOGS_LIST_WINDOWS="C:\AzureData\CustomDataSetupScript.log" # space-separated log file locations
 ```

--- a/pkg/collector/kubeobjects_collector.go
+++ b/pkg/collector/kubeobjects_collector.go
@@ -2,27 +2,35 @@ package collector
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/Azure/aks-periscope/pkg/utils"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	memory "k8s.io/client-go/discovery/cached"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/kubectl/pkg/describe"
 )
 
 // KubeObjectsCollector defines a KubeObjects Collector struct
 type KubeObjectsCollector struct {
-	data        map[string]string
-	kubeconfig  *restclient.Config
-	runtimeInfo *utils.RuntimeInfo
+	data          map[string]string
+	kubeconfig    *restclient.Config
+	commandRunner *utils.KubeCommandRunner
+	runtimeInfo   *utils.RuntimeInfo
 }
 
 // NewKubeObjectsCollector is a constructor
 func NewKubeObjectsCollector(config *restclient.Config, runtimeInfo *utils.RuntimeInfo) *KubeObjectsCollector {
 	return &KubeObjectsCollector{
-		data:        make(map[string]string),
-		kubeconfig:  config,
-		runtimeInfo: runtimeInfo,
+		data:          make(map[string]string),
+		kubeconfig:    config,
+		commandRunner: utils.NewKubeCommandRunner(config),
+		runtimeInfo:   runtimeInfo,
 	}
 }
 
@@ -36,40 +44,81 @@ func (collector *KubeObjectsCollector) CheckSupported() error {
 
 // Collect implements the interface method
 func (collector *KubeObjectsCollector) Collect() error {
-	// Creates the clientset
-	clientset, err := kubernetes.NewForConfig(collector.kubeconfig)
+	// Create a discovery client for querying resource metadata
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(collector.kubeconfig)
 	if err != nil {
-		return fmt.Errorf("getting access to K8S failed: %w", err)
+		return fmt.Errorf("error creating discovery client: %w", err)
 	}
+
+	// Create a RESTMapper to handle the mapping between GroupKind and GroupVersionResource
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
 
 	for _, kubernetesObject := range collector.runtimeInfo.KubernetesObjects {
 		kubernetesObjectParts := strings.Split(kubernetesObject, "/")
-		nameSpace := kubernetesObjectParts[0]
-		objectType := kubernetesObjectParts[1]
-
-		// List the pods in the given namespace
-		podList, err := utils.GetPods(clientset, nameSpace)
-		if err != nil {
-			return fmt.Errorf("getting pods failed: %w", err)
+		if len(kubernetesObjectParts) < 2 {
+			log.Printf("Invalid kube-objects value: %s", kubernetesObject)
+			continue
 		}
 
-		for _, pod := range podList.Items {
-			d := describe.PodDescriber{
-				Interface: clientset,
-			}
+		namespace := kubernetesObjectParts[0]
+		groupResource := schema.ParseGroupResource(kubernetesObjectParts[1])
 
-			output, err := d.Describe(pod.Namespace, pod.Name, describe.DescriberSettings{
-				ShowEvents: true,
-			})
+		groupVersionKind, err := mapper.KindFor(groupResource.WithVersion(""))
+		if err != nil {
+			log.Printf("Unable to determine Kind for resource %s: %v", groupResource.String(), err)
+			continue
+		}
+
+		describer, ok := describe.DescriberFor(groupVersionKind.GroupKind(), collector.kubeconfig)
+		if !ok {
+			log.Printf("Unable to create Describer for Kind %s", groupVersionKind.String())
+			continue
+		}
+
+		// Get the resources within the namespace to describe
+		var resourceNames []string
+		if len(kubernetesObjectParts) > 2 {
+			resourceNames = []string{kubernetesObjectParts[2]}
+		} else {
+			resourceNames, err = collector.getResourcesInNamespace(mapper, &groupResource, namespace)
 			if err != nil {
-				return fmt.Errorf("getting description failed: %w", err)
+				log.Printf("Unable to get %s resources in %s: %v", groupResource.String(), namespace, err)
+				continue
+			}
+		}
+
+		for _, resourceName := range resourceNames {
+			output, err := describer.Describe(namespace, resourceName, describe.DescriberSettings{ShowEvents: true})
+			if err != nil {
+				log.Printf("Error describing %s %s in namespace %s: %v", groupVersionKind.String(), resourceName, namespace, err)
+				continue
 			}
 
-			collector.data[pod.Namespace+"_"+objectType+"_"+pod.Name] = output
+			key := fmt.Sprintf("%s_%s_%s", namespace, groupResource.String(), resourceName)
+			collector.data[key] = output
 		}
 	}
 
 	return nil
+}
+
+func (collector *KubeObjectsCollector) getResourcesInNamespace(mapper meta.RESTMapper, groupResource *schema.GroupResource, namespace string) ([]string, error) {
+	groupVersionResource, err := mapper.ResourceFor(groupResource.WithVersion(""))
+	if err != nil {
+		return []string{}, fmt.Errorf("error determining Version for resource %s: %v", groupResource.String(), err)
+	}
+
+	resources, err := collector.commandRunner.GetUnstructuredList(&groupVersionResource, namespace, &metav1.ListOptions{})
+	if err != nil {
+		return []string{}, fmt.Errorf("error listing %s: %v", groupVersionResource.String(), err)
+	}
+
+	resourceNames := make([]string, len(resources.Items))
+	for i, resource := range resources.Items {
+		resourceNames[i] = resource.GetName()
+	}
+
+	return resourceNames, nil
 }
 
 func (collector *KubeObjectsCollector) GetData() map[string]string {

--- a/pkg/collector/kubeobjects_collector_test.go
+++ b/pkg/collector/kubeobjects_collector_test.go
@@ -109,8 +109,22 @@ func TestKubeObjectsCollectorCollect(t *testing.T) {
 			want:             map[string]*regexp.Regexp{},
 		},
 		{
-			name:             "unknown resource should be skipped",
+			name:             "unknown resource type should be skipped",
 			requestedObjects: []string{"kube-system/notaresource"},
+			config:           fixture.PeriscopeAccess.ClientConfig,
+			wantErr:          false,
+			want:             map[string]*regexp.Regexp{},
+		},
+		{
+			name:             "undescribable resource type should be skipped",
+			requestedObjects: []string{"kube-system/events"},
+			config:           fixture.PeriscopeAccess.ClientConfig,
+			wantErr:          false,
+			want:             map[string]*regexp.Regexp{},
+		},
+		{
+			name:             "missing resource should be skipped",
+			requestedObjects: []string{"kube-system/pod/notexisting"},
 			config:           fixture.PeriscopeAccess.ClientConfig,
 			wantErr:          false,
 			want:             map[string]*regexp.Regexp{},

--- a/pkg/collector/osm_collector_test.go
+++ b/pkg/collector/osm_collector_test.go
@@ -109,30 +109,7 @@ func TestOsmCollectorCollect(t *testing.T) {
 			}
 			data := c.GetData()
 
-			missingDataKeys := []string{}
-			for key, regexp := range tt.want {
-				value, ok := data[key]
-				if ok {
-					if !regexp.MatchString(value) {
-						t.Errorf("unexpected value for %s\n\texpected: %s\n\tfound: %s", key, regexp.String(), value)
-					}
-				} else {
-					missingDataKeys = append(missingDataKeys, key)
-				}
-			}
-			if len(missingDataKeys) > 0 {
-				t.Errorf("missing keys in Collect result:\n%s", strings.Join(missingDataKeys, "\n"))
-			}
-
-			unexpectedDataKeys := []string{}
-			for key := range data {
-				if _, ok := tt.want[key]; !ok {
-					unexpectedDataKeys = append(unexpectedDataKeys, key)
-				}
-			}
-			if len(unexpectedDataKeys) > 0 {
-				t.Errorf("unexpected keys in Collect result:\n%s", strings.Join(unexpectedDataKeys, "\n"))
-			}
+			compareCollectorData(t, tt.want, data)
 		})
 	}
 }

--- a/pkg/collector/smi_collector_test.go
+++ b/pkg/collector/smi_collector_test.go
@@ -85,30 +85,7 @@ func TestSmiCollectorCollect(t *testing.T) {
 			}
 			data := c.GetData()
 
-			missingDataKeys := []string{}
-			for key, regexp := range tt.want {
-				value, ok := data[key]
-				if ok {
-					if !regexp.MatchString(value) {
-						t.Errorf("unexpected value for %s\n\texpected: %s\n\tfound: %s", key, regexp.String(), value)
-					}
-				} else {
-					missingDataKeys = append(missingDataKeys, key)
-				}
-			}
-			if len(missingDataKeys) > 0 {
-				t.Errorf("missing keys in Collect result:\n%s", strings.Join(missingDataKeys, "\n"))
-			}
-
-			unexpectedDataKeys := []string{}
-			for key := range data {
-				if _, ok := tt.want[key]; !ok {
-					unexpectedDataKeys = append(unexpectedDataKeys, key)
-				}
-			}
-			if len(unexpectedDataKeys) > 0 {
-				t.Errorf("unexpected keys in Collect result:\n%s", strings.Join(unexpectedDataKeys, "\n"))
-			}
+			compareCollectorData(t, tt.want, data)
 		})
 	}
 }

--- a/pkg/test/resources/tools-resources/kube-objects/test-resources.yaml
+++ b/pkg/test/resources/tools-resources/kube-objects/test-resources.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-1
+data:
+  test_value_1: "a"
+  test_value_2: "b"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-2
+data:
+  test_value_1: "c"
+  test_value_2: "d"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-3
+data:
+  test_value_1: "e"
+  test_value_2: "f"


### PR DESCRIPTION
Addresses #187

As well as using the resource type from the `<namespace>/<resource-type>` values in the `DIAGNOSTIC_KUBEOBJECTS_LIST` environment variable, this also allows specifying individual resources with an extra `/`, e.g. `<namespace>/<resource-type>/<resource-name>` (because the az CLI examples claim that behaviour).

This also adds a number of automated tests to cover the behaviour being fixed.