### PR TITLE
Add automatic release tag generation.

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -34,6 +34,15 @@ jobs:
         run: |
            echo "Version: ${{ steps.changelog_reader.outputs.version }}"
            echo "Changes: ${{ steps.changelog_reader.outputs.changes }}"
+      - name: Create a Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        with:
+          tag_name : ${{ steps.package_version.outputs.current-version}}
+          release_name: ${{ steps.package_version.outputs.current-version}}
+          body: Publish ${{ steps.changelog_reader.outputs.changes }}
       - name: 'Az CLI login'
         uses: azure/login@v1
         with:


### PR DESCRIPTION
This PR is to add the automation of release tag generation when MCR gets published, so all manual work should be now automatic.

Please note: 
* I think currently we used to generate release tag with `v*.*.*` which will be now without `v` in front I feel it is for good because the image never has `v` as well.

Please feel free to add any further idea/thoughts.

So all we need to do is following:

* Create release PR with Changelog.md file and then after that gets merged.
* Click - `Publish mcr` action, which will look at Changelog, create release tag before mar release. (That is it :shipit: 🎊)

thank you so much, cc: @peterbom and @rzhang628 🙏☕️❤️🥷

