### PR TITLE
Update deployment notes for image registries to include ACR as well as GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,11 @@ CGO_ENABLED=0 GOOS=linux go build -mod=mod github.com/Azure/aks-periscope/cmd/ak
 
 See [this guide](./docs/testing.md) for running automated tests in a CI or development environment.
 
-**Tip**: To test local changes, there are instructions for running Periscope in a `Kind` cluster in the ['dev' Kustomize overlay notes](./deployment/overlays/dev/README.md). This allows for altering the configuration without touching any source-controlled files.
+### Manual Testing
 
-**Tip**: To test changes in a GitHub branch, there are instructions for running images published to a local GHCR registry in the ['dynamic-image' Kustomize overlay notes](./deployment/overlays/dynamic-image/README.md#ghcr).This is especially useful for verifying Windows images.
+You can build and run Periscope locally in a `Kind` cluster using the ['dev' Kustomize overlay notes](./deployment/overlays/dev/README.md).
+
+To build and push a Docker image to an external registry (GHCR or ACR), and then deploy that to any (local or cloud-hosted) cluster, please refer to the ['dynamic-image' Kustomize overlay notes](./deployment/overlays/dynamic-image/README.md#ghcr).
 
 ## Dependent Consuming Tools and Working Contract
 

--- a/deployment/overlays/dev/README.md
+++ b/deployment/overlays/dev/README.md
@@ -1,6 +1,8 @@
 # Dev Overlay
 
-This can be used for running a locally-built Periscope image in a `Kind` cluster. Because `Kind` runs on Linux only, the Linux `DaemonSet` will refer to the locally-built image, whereas the Windows `DaemonSet` will refer to the latest published production Windows MCR image.
+This can be used for running a locally-built Periscope image in a `Kind` cluster. The environment files are `gitignore`d to avoid committing any credentials or user-specific configuration to source control.
+
+Because `Kind` runs on Linux only, the Linux `DaemonSet` will refer to the locally-built image, whereas the Windows `DaemonSet` will refer to the latest published production Windows MCR image (to test Windows changes, use the ['dynamic image'](../dynamic-image/README.md) overlay).
 
 It will deploy to its own namespace, `aks-periscope-dev` to avoid conflicts with any existing Periscope deployment.
 

--- a/deployment/overlays/dynamic-image/README.md
+++ b/deployment/overlays/dynamic-image/README.md
@@ -1,30 +1,85 @@
 # Dynamic Image Overlay Template
 
-This is a template for an overlay, rather than an overlay itself, because although `Kustomize` supports dynamic configuration for `ConfigMap` and `Secret` resources via `.env` files, it does not allow dynamically specifying image names/tags.
+This overlay is used to deploy specific Periscope Docker images to a cluster.
 
-This allows us to specify image/tag identifiers as well as runtime configuration, generating an overlay in the `overlays/temp` folder. This overlay can then be deployed to any cluster (including `Kind` and AKS).
+(It is really a *template* for an overlay, rather than an actual overlay, because although `Kustomize` supports dynamic configuration for `ConfigMap` and `Secret` resources via `.env` files, it does not allow dynamically specifying image names/tags.)
 
-## Image Sources
+The typical use-case would be to manually test an in-development build of Periscope on a managed cluster. You might do this if your development environment does not have Docker/Kind available, or does not support the feature you wish to test. One example is running Periscope on Windows nodes (further notes on creating a cluster with Windows nodes is [below](#creating-a-windows-cluster)).
 
-Some uses for this template are listed below.
+If the resources are being deployed to a managed cluster, your Periscope build will need to be published to an external image registry. The options described here are:
+- ACR: If you have local (not yet pushed) changes that you want to test on a managed AKS cluster, you can publish images to an ACR from your local filesystem.
+- GHCR: If you have pushed changes to a fork of the Periscope repository on which you have permission to publish releases, you can publish images to GHCR from a branch in your repository.
 
-### CI Build
+## Publishing Images
 
-The [CI Pipeline](../../../.github/workflows/ci-pipeline.yaml) builds an image accessible only to a local `Kind` cluster. The generated overlay deploys Periscope resources that reference this image.
+The steps required to build and publish an image depend on the registry you're publishing to.
 
-### GHCR
+### Publishing to ACR
 
-It can be useful to test a particular GitHub branch. We can generate an overlay for deploying the images generated from that branch. This is especially useful for testing behaviour in Windows containers, because the typical development environment does not have `Docker` configured for running Windows containers (and if it does, the OS may not match the AKS Windows OS). Further notes on creating a cluster with Windows nodes is [below](#creating-a-windows-cluster).
+#### 1. Initial Setup
 
-To make both the Docker images available to the cluster, they must be published to a container registry that allows anonymous pull access. To do this:
-1. Push the branch you want to deploy to your local fork of the Periscope repository.
-2. Run the [Building and Pushing to GHCR](../../../.github/workflows/build-and-publish.yml) workflow in GitHub Actions (making sure to select the correct branch).
-3. Take note of the published image tags (e.g. '0.0.8').
-4. [First time only] Under Package Settings in GitHub, set each package's visibility to 'public'.
+If the AKS cluster and ACR are in a subscription in which you have the `Owner` role, you can attach the ACR to your cluster without the need to supply credentials in the deployment spec (the `Owner` role is needed for ACR role assignments).
+
+```sh
+rg=...
+aks_name=...
+acr_name=...
+az aks update --resource-group $rg --name $aks_name --attach-acr $acr_name
+```
+
+If you're not a subscription owner, you can configure the Periscope deployment to authenticate using the ACR's Admin account. To enable the admin account on the ACR, run:
+
+```sh
+acr_name=...
+az acr update -n $acr_name --admin-enabled true
+```
+
+#### 2. Set Environment Variables for ACR
+
+These variables are needed for both publishing the images and deploying Periscope. The image tag can be set to whatever you like.
+
+```sh
+acr_name=...
+export IMAGE_TAG=...
+export IMAGE_NAME_LINUX=${acr_name}.azurecr.io/aks/periscope
+export IMAGE_NAME_WINDOWS=${acr_name}.azurecr.io/aks/periscope-win
+```
+
+#### 3. Run an ACR Build
+
+You can build and publish both Linux and Windows images using the `az acr build` command:
+
+```sh
+az acr build --registry $acr_name -f ./builder/Dockerfile.linux -t $IMAGE_NAME_LINUX:$IMAGE_TAG --platform linux/amd64 .
+az acr build --registry $acr_name -f ./builder/Dockerfile.windows -t $IMAGE_NAME_WINDOWS:$IMAGE_TAG --platform windows/amd64 .
+```
+
+### Publishing to GHCR
+
+#### 1. Run the Publish Workflow
+
+Make a note of the latest version heading in [the changelog](../../../CHANGELOG.md). This will be used for the published image tags.
+
+Run the [Building and Pushing to GHCR](../../../.github/workflows/build-and-publish.yml) workflow in GitHub Actions (making sure to select the correct branch).
+
+#### 2. Set Environment Variables for GHCR
+
+These variables will be needed for deploying Periscope. Fill in the name of the GitHub fork, and the published image tag.
+
+```sh
+repo_username=...
+export IMAGE_TAG=...
+export IMAGE_NAME_LINUX=ghcr.io/${REPO_USERNAME}/aks/periscope
+export IMAGE_NAME_WINDOWS=ghcr.io/${REPO_USERNAME}/aks/periscope-win
+```
+
+#### 3. Ensure Packages are Public
+
+This only needs to be done once for each of the Linux and Windows packages. Under Package Settings in GitHub, set each package's visibility to 'public'.
 
 ## Setting up Configuration Data
 
-Like the `dev` overlay, we need to put storage account configuration into an `.env.secret` file before running `Kustomize`.
+As with the `dev` overlay, you put storage account configuration into an `.env.secret` file before running `Kustomize`.
 
 ```sh
 # Create a SAS
@@ -50,9 +105,24 @@ AZURE_BLOB_ACCOUNT_NAME=${stg_account}
 AZURE_BLOB_SAS_KEY=?${sas}
 AZURE_BLOB_CONTAINER_NAME=${blob_container}
 EOF
+
+# If using an ACR's admin account credentials to access the Periscope image:
+acr_name=...
+acr_username=$(az acr credential show -n $acr_name --query username --output tsv)
+acr_password=$(az acr credential show -n $acr_name --query passwords[0].value --output tsv)
+cat <<EOF > ./deployment/overlays/temp/acr.dockerconfigjson
+{
+    "auths": {
+        "${acr_name}.azurecr.io": {
+            "username": "${acr_username}",
+            "password": "${acr_password}"
+        }
+    }
+}
+EOF
 ```
 
-We can also override diagnostic configuration variables:
+You can also override diagnostic configuration variables:
 
 ```sh
 echo "DIAGNOSTIC_KUBEOBJECTS_LIST=kube-system default" > ./deployment/overlays/temp/.env.config
@@ -60,29 +130,29 @@ echo "DIAGNOSTIC_KUBEOBJECTS_LIST=kube-system default" > ./deployment/overlays/t
 
 ## Deploying Periscope
 
-We first need to specify environment variables for image name and tag. For example, for GHCR:
+First ensure your environment variables are set up. See notes for [ACR](#2-set-environment-variables-for-acr) and [GHCR](#2-set-environment-variables-for-ghcr).
+
+Next you can use `envsubst` to generate a `Kustomize` overlay from the template (this is placed in the `overlays/temp` directory, which is excluded from source control), and deploy it with `kubectl`.
 
 ```sh
-REPO_USERNAME=...
-export IMAGE_TAG=...
-export IMAGE_NAME_LINUX=ghcr.io/${REPO_USERNAME}/aks/periscope
-export IMAGE_NAME_WINDOWS=ghcr.io/${REPO_USERNAME}/aks/periscope-win
-```
+# Create the required config files if they don't already exist
+touch ./deployment/overlays/temp/.env.config ./deployment/overlays/temp/acr.dockerconfigjson
 
-We then generate the `kustomization.yaml` and dependencies in `overlays/temp`:
-
-```sh
-touch ./deployment/overlays/temp/.env.config # In case it doesn't exist already
+# Generate the kustomization.yaml
 cat ./deployment/overlays/dynamic-image/kustomization.template.yaml | envsubst > ./deployment/overlays/temp/kustomization.yaml
-```
 
-And finally deploy the resources:
-
-```sh
 # Ensure kubectl has the right cluster context
 export KUBECONFIG=...
+
 # Deploy
 kubectl apply -k ./deployment/overlays/temp
+```
+
+Each time we want Periscope to run, we supply a new run ID for it. This can be done with:
+
+```sh
+run_id=$(date -u '+%Y-%m-%dT%H-%M-%SZ')
+kubectl patch configmap -n aks-periscope diagnostic-config -p="{\"data\":{\"DIAGNOSTIC_RUN_ID\": \"$run_id\"}}"
 ```
 
 ---

--- a/deployment/overlays/dynamic-image/kustomization.template.yaml
+++ b/deployment/overlays/dynamic-image/kustomization.template.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: aks-periscope
+
 bases:
 - ../../base
 
@@ -17,9 +19,21 @@ secretGenerator:
   behavior: replace
   envs:
   - .env.secret
+- name: acr-secret
+  behavior: create
+  files:
+  - .dockerconfigjson=acr.dockerconfigjson
 
 configMapGenerator:
 - name: diagnostic-config
   behavior: merge
   envs:
   - .env.config
+
+patches:
+- target:
+    kind: DaemonSet
+  patch: |-
+    - op: add
+      path: /spec/template/spec/imagePullSecrets
+      value: [{ name: acr-secret }]


### PR DESCRIPTION
This attempts to address some shortcomings in the READMEs for deploying Periscope using external image registries.

Thanks to @bravebeaver for pointing out that you can use the `az aks update --attach-acr` command to link an AKS cluster to an ACR.

Being able to use ACR is really handy because it allows us to publish and test images from a local filesystem (without needing to push to GitHub).

Even when it's not possible to use the `attach-acr` approach (which requires subscription `Owner` role assignment), you can still deploy a secret containing ACR credentials, so that approach is also described here.