### PR TITLE
Remove unnecessary permissions in documentation for SAS generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ All placeholders in angled brackets (`<`/`>`) need to be substituted for the rel
 - `SAS_KEY`: An [Account SAS](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#account-sas) including preceding `?` with [parameters](https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specify-the-account-sas-parameters):
   - `ss`: `b` (Service: blob)
   - `srt`: `sco` (Resource types: service, container and object)
-  - `sp`: `rlacwd` (Permissions: read, list, add, create, write, delete)
+  - `sp`: `rlacw` (Permissions: read, list, add, create, write)
 - `RUN_ID`: The identifier for a particular 'run' of Periscope, by convention a timestamp formatted as `YYYY-MM-DDThh-mm-ssZ`. This will become the topmost container within `CONTAINER_NAME`.
 
 You can then deploy Periscope by running:

--- a/deployment/overlays/dev/README.md
+++ b/deployment/overlays/dev/README.md
@@ -31,7 +31,7 @@ sas_expiry=`date -u -d "30 minutes" '+%Y-%m-%dT%H:%MZ'`
 sas=$(az storage account generate-sas \
     --account-name $stg_account \
     --subscription $sub_id \
-    --permissions rwdlacup \
+    --permissions rlacw \
     --services b \
     --resource-types sco \
     --expiry $sas_expiry \

--- a/deployment/overlays/dynamic-image/README.md
+++ b/deployment/overlays/dynamic-image/README.md
@@ -95,7 +95,7 @@ sas_expiry=`date -u -d "30 minutes" '+%Y-%m-%dT%H:%MZ'`
 sas=$(az storage account generate-sas \
     --account-name $stg_account \
     --subscription $sub_id \
-    --permissions rwdlacup \
+    --permissions rlacw \
     --services b \
     --resource-types sco \
     --expiry $sas_expiry \

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -10,7 +10,7 @@ deployment/aks-periscope.yaml
 By default, the collected logs, metrics and node level diagnostic information will be exported to Azure Blob Service. An Azure Blob Service account and a Shared Access Signature (SAS) token need to be provisioned in advance. These values should be based64 encoded and be set in the `AZURE_BLOB_ACCOUNT_NAME` and `AZURE_BLOB_SAS_KEY` in above aks-periscope.yaml.
 
    * `AZURE_BLOB_ACCOUNT_NAME` holds a base64 encoded storage account ID (e.g. "mystorageaccountname"). 
-   * `AZURE_BLOB_SAS_KEY` holds a base64 encoded **Account level** SAS token granting the following permissions: ss=b srt=sco sp=rwdlacup (description of params here: https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specifying-account-sas-parameters). 
+   * `AZURE_BLOB_SAS_KEY` holds a base64 encoded **Account level** SAS token granting the following permissions: ss=b srt=sco sp=rlacw (description of params here: https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specifying-account-sas-parameters). 
        * this should be just the **query string** component of the SAS key, e.g. "?sv=2019-12-12&ss=btqf&...." not the full uri. 
        * Azure Storage Explorer or the Azure Portal can be used to generate the SAS.
 


### PR DESCRIPTION
We are currently advising users to generate a SAS containing permissions for unused or invalid [operation parameters](https://learn.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specify-the-account-sas-parameters):
- 'd' (delete): not used - we are not deleting any containers or blobs
- 'u' (update): invalid - only for queue messages and table entities
- 'p' (process): invalid - only for queue messages

Also, the SAS generation examples using as CLI are not consistent with the main README.

This updates both, so that the remaining operations are: read, list, add (append blob), create and write.