### PR TITLE
Add nsenter to Linux Periscope image

### DIFF
--- a/builder/Dockerfile.linux
+++ b/builder/Dockerfile.linux
@@ -18,9 +18,22 @@ COPY . .
 
 RUN go build ./cmd/aks-periscope
 
+# Add dependencies for building nsenter
+RUN apt-get update && \
+    apt-get install -y autoconf autopoint bison gettext libtool
+
+# Create a statically-compiled nsenter binary (see: https://github.com/alexei-led/nsenter/blob/master/Dockerfile)
+# nsenter versions: https://www.kernel.org/pub/linux/utils/util-linux/
+ADD https://github.com/util-linux/util-linux/archive/v2.38.tar.gz .
+RUN tar -xf v2.38.tar.gz && mv util-linux-2.38 util-linux
+WORKDIR /build/util-linux
+RUN ./autogen.sh && ./configure
+RUN make LDFLAGS="--static" nsenter
+
 # Runner
 FROM $BASE_IMAGE
 
 COPY --from=builder /build/aks-periscope /
+COPY --from=builder /build/util-linux/nsenter /usr/bin/
 
 ENTRYPOINT ["/aks-periscope"]


### PR DESCRIPTION
This fixes a bug introduced with the recent change to use distroless images, which don't contain the `nsenter` binary. This utility is still required to run processes on the host VM, and is used by the `iptables`, kubelet-command and system-logs collectors, and so those collectors are currently failing.

Note: Windows images are unaffected, since they never relied on `nsenter` and those collectors are disabled on Windows.