### PR TITLE
Update resource requests and limits for all Periscope pods

### DIFF
--- a/deployment/base/daemon-set.yaml
+++ b/deployment/base/daemon-set.yaml
@@ -41,10 +41,10 @@ spec:
           mountPath: /etchostlogs
         resources:
           requests:
-            memory: "500Mi"
-            cpu: "250m"
+            memory: "40Mi"
+            cpu: "1m"
           limits:
-            memory: "2000Mi"
+            memory: "500Mi"
             cpu: "1000m"
       volumes:
       - name: diag-config-volume
@@ -102,10 +102,10 @@ spec:
           mountPath: /AzureData
         resources:
           requests:
-            memory: "500Mi"
-            cpu: "250m"
+            memory: "100Mi"
+            cpu: "100m"
           limits:
-            memory: "2000Mi"
+            memory: "1Gi"
             cpu: "1000m"
       volumes:
       - name: diag-config-volume

--- a/deployment/components/win-hpc/CollectDiagnostics.ps1
+++ b/deployment/components/win-hpc/CollectDiagnostics.ps1
@@ -12,7 +12,7 @@ $previousRunId = ""
 
 while ($true) {
     $runId = Get-Content $runIdPath
-    if ($runId -ne $previousRunId) {
+    if ($runId -and $runId -ne $previousRunId) {
         Write-Host "Collecting diagnostics for ${runId}"
 
         # The FileInfo containing the zip file is the last output from the script

--- a/deployment/components/win-hpc/daemon-set.yaml
+++ b/deployment/components/win-hpc/daemon-set.yaml
@@ -35,6 +35,13 @@ spec:
           mountPath: config
         - name: script-config-volume
           mountPath: scripts
+        resources:
+          requests:
+            memory: "1000Mi"
+            cpu: "100m"
+          limits:
+            memory: "2000Mi"
+            cpu: "1000m"
       volumes:
       - name: diag-config-volume
         configMap:
@@ -83,6 +90,13 @@ spec:
           mountPath: config
         - name: script-config-volume
           mountPath: scripts
+        resources:
+          requests:
+            memory: "1000Mi"
+            cpu: "100m"
+          limits:
+            memory: "2000Mi"
+            cpu: "1000m"
       volumes:
       - name: diag-config-volume
         configMap:


### PR DESCRIPTION
This addresses #219.

The values are based on the actual pod memory (from metrics server) on an AKS cluster (incorporating a buffer to allow for some future extra memory usage or clusters where there is more data to process).

The Windows 'diagnostics collection' DaemonSet did not already have a resources block, so this is added here. The numbers are extremely high for this because the PowerShell script that does the log collection is very memory-hungry when compressing events into a zip file.

This also fixes a minor bug in the Windows log collection script that would occasionally result in it running without a `run_id` value when Periscope was repeatedly deployed to the same cluster without deletion.