### PR TITLE
Group k8s.io dependencies so that dependabot updates them in one go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
+    groups:
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Updating all k8s.io dependencies in a single PR should reduce the chance of build errors resulting from incompatibilities when upgrading to later versions. It should also minimize the number of PRs we need to review and merge.

Relates to #234 