### PR TITLE
Use 1ES runner for workflow jobs that push to ACR

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -63,7 +63,8 @@ jobs:
         release_name: ${{ needs.common.outputs.version }}
         body: Publish ${{ needs.common.outputs.changes }}
   publish:
-    runs-on: ${{ matrix.os }}
+    runs-on:
+      labels: [self-hosted, "1ES.Pool=${{ matrix.runner }}"]
     needs: common
     permissions:
       contents: read
@@ -75,16 +76,19 @@ jobs:
         os: [ubuntu-latest, windows-2019, windows-2022]
         include:
         - os: ubuntu-latest
+          runner: ${{ vars.RUNNER_BASE_NAME }}-ubuntu
           file: ./builder/Dockerfile.linux
           baseimage: 'mcr.microsoft.com/cbl-mariner/distroless/base:2.0'
           tagext: 'mariner2.0'
           canpatch: true
         - os: windows-2019
+          runner: ${{ vars.RUNNER_BASE_NAME }}-win2019
           file: ./builder/Dockerfile.windows
           baseimage: 'mcr.microsoft.com/windows/nanoserver:ltsc2019'
           tagext: 'nanoserver2019'
           canpatch: false
         - os: windows-2022
+          runner: ${{ vars.RUNNER_BASE_NAME }}-win2022
           file: ./builder/Dockerfile.windows
           baseimage: 'mcr.microsoft.com/windows/nanoserver:ltsc2022'
           tagext: 'nanoserver2022'
@@ -101,14 +105,10 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     # Perform a 'docker login' so that we can push to the ACR that provides the MCR images.
     # This requires an Az login first.
-    - name: Az CLI Login
-      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.4.6
-      with:
-        client-id: ${{ vars.AZURE_CLIENT_ID }}
-        tenant-id: ${{ vars.AZURE_TENANT_ID }}
-        subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     - name: Authenticate to ACR
-      run: az acr login -n ${{ vars.AZURE_REGISTRY_SERVER }}
+      run: |
+        az login --identity
+        az acr login -n ${{ vars.AZURE_REGISTRY_SERVER }}
     # Perform a 'docker login' so that we can push to the current repo's GHCR. We will push the unpatched
     # images to GHCR first, run a Trivy scan and Copa patch on those, and then push the patched images
     # to both GHCR and ACR.
@@ -182,7 +182,8 @@ jobs:
       acr_win2019: ${{ steps.getref.outputs.windows-2019-acr-image-ref }}
       acr_win2022: ${{ steps.getref.outputs.windows-2022-acr-image-ref }}
   update-manifest:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-ubuntu"]
     needs: [common, publish]
     permissions:
       id-token: write
@@ -197,14 +198,10 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: Az CLI Login
-      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.4.6
-      with:
-        client-id: ${{ vars.AZURE_CLIENT_ID }}
-        tenant-id: ${{ vars.AZURE_TENANT_ID }}
-        subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     - name: Authenticate to ACR
-      run: az acr login -n ${{ vars.AZURE_REGISTRY_SERVER }}
+      run: |
+        az login --identity
+        az acr login -n ${{ vars.AZURE_REGISTRY_SERVER }}
     - name: Authenticate to GHCR
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       with:

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -43,7 +43,8 @@ jobs:
       ghcr_image_id: ${{ steps.read_metadata.outputs.ghcr_image_id }}
       tag_id_base: ${{ steps.read_metadata.outputs.tag_id_base }}
   patch:
-    runs-on: ${{ matrix.os }}
+    runs-on:
+      labels: [self-hosted, "1ES.Pool=${{ matrix.runner }}"]
     needs: common
     permissions:
       id-token: write
@@ -54,33 +55,31 @@ jobs:
         os: [ubuntu-latest, windows-2019, windows-2022]
         include:
         - os: ubuntu-latest
+          runner: ${{ vars.RUNNER_BASE_NAME }}-ubuntu
           tagext: 'mariner2.0'
           canpatch: true
         - os: windows-2019
+          runner: ${{ vars.RUNNER_BASE_NAME }}-win2019
           tagext: 'nanoserver2019'
           canpatch: false
         - os: windows-2022
+          runner: ${{ vars.RUNNER_BASE_NAME }}-win2022
           tagext: 'nanoserver2022'
           canpatch: false
     defaults:
       run:
         shell: pwsh
     steps:
-    # Perform a 'docker login' so that we can push to the ACR that provides the MCR images.
-    # This requires an Az login first.
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
       with:
         egress-policy: audit
-
-    - name: Az CLI Login
-      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.4.6
-      with:
-        client-id: ${{ vars.AZURE_CLIENT_ID }}
-        tenant-id: ${{ vars.AZURE_TENANT_ID }}
-        subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+    # Perform a 'docker login' so that we can push to the ACR that provides the MCR images.
+    # This requires an Az login first.
     - name: Authenticate to ACR
-      run: az acr login -n ${{ vars.AZURE_REGISTRY_SERVER }}
+      run: |
+        az login --identity
+        az acr login -n ${{ vars.AZURE_REGISTRY_SERVER }}
     # Perform a 'docker login' so that we can push to the current repo's GHCR. We will run a Trivy scan
     # on the GHCR images, perform a Copa patch if there are vulnerabilities, and then push the patched images
     # to both GHCR and ACR.
@@ -144,7 +143,8 @@ jobs:
       acr_win2019: ${{ steps.getref.outputs.windows-2019-acr-image-ref }}
       acr_win2022: ${{ steps.getref.outputs.windows-2022-acr-image-ref }}
   update-manifest:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-ubuntu"]
     needs: [common, patch]
     permissions:
       id-token: write
@@ -153,20 +153,15 @@ jobs:
       run:
         shell: pwsh
     steps:
-    # As for the 'patch' job, we need to 'docker login' to both GHCR and ACR to push manifests.
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
       with:
         egress-policy: audit
-
-    - name: Az CLI Login
-      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.4.6
-      with:
-        client-id: ${{ vars.AZURE_CLIENT_ID }}
-        tenant-id: ${{ vars.AZURE_TENANT_ID }}
-        subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+    # As for the 'patch' job, we need to 'docker login' to both GHCR and ACR to push manifests.
     - name: Authenticate to ACR
-      run: az acr login -n ${{ vars.AZURE_REGISTRY_SERVER }}
+      run: |
+        az login --identity
+        az acr login -n ${{ vars.AZURE_REGISTRY_SERVER }}
     - name: Authenticate to GHCR
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       with:


### PR DESCRIPTION
This updates the publish and patch workflows to use Azure 1ES runner pools. These are already configured with an identity that has permission to push to the ACR, meaning the service principal with federated GitHub permissions is no longer required, and the related variables (`CLIENT_ID`, `SUBSCRIPTION_ID` and `TENANT_ID`) can be deleted.

We need a new variable, `RUNNER_BASE_NAME`, which is the name of the 1ES pools minus the OS postfix (`-ubuntu`, `-win2019` and `-win2022`).

Example successful workflow runs from fork:
- [Build and Publish](https://github.com/peterbom/aks-periscope/actions/runs/7866263354/job/21460697261)
- [Patch](https://github.com/peterbom/aks-periscope/actions/runs/7866498780/job/21460987570)

**NOTE:** This should not be merged until we have:
- ~~created our production runners~~
- ~~created the production ACR~~
- ~~updated the metadata for creating the MCR images~~
- ~~updated the `AZURE_REGISTRY_SERVER` variable and added the `RUNNER_BASE_NAME` variable.~~